### PR TITLE
Fix flake8 errors

### DIFF
--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -32,21 +32,21 @@ def setup_logger(log_file_location, level):
 
 if __name__ == "__main__":
     # Read configuration
-    configuration_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'configuration.ini'))
-    CONFIGURATION = Configuration(configuration_path)
+    CONFIGURATION_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'configuration.ini'))
+    CONFIGURATION = Configuration(CONFIGURATION_PATH)
 
     # Set up logging
     LOGGER = setup_logger(CONFIGURATION.log_folder_location, logging.INFO)
     LOGGER.info("Starting DITTO Web API")
 
     # Set up services
-    external_data_service = ExternalDataService(CONFIGURATION)
-    internal_data_service = InternalDataService(CONFIGURATION)
-    data_replication_service = DataReplicationService(external_data_service, internal_data_service, LOGGER)
+    EXTERNAL_DATA_SERVICE = ExternalDataService(CONFIGURATION)
+    INTERNAL_DATA_SERVICE = InternalDataService(CONFIGURATION)
+    DATA_REPLICATION_SERVICE = DataReplicationService(EXTERNAL_DATA_SERVICE, INTERNAL_DATA_SERVICE, LOGGER)
 
     # Launch app
-    app = tornado.web.Application([
-        (r"/listpresent", ListPresentHandler, dict(data_replication_service=data_replication_service)),
+    APP = tornado.web.Application([
+        (r"/listpresent", ListPresentHandler, dict(data_replication_service=DATA_REPLICATION_SERVICE)),
     ])
-    app.listen(8888)
+    APP.listen(8888)
     tornado.ioloop.IOLoop.current().start()

--- a/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
@@ -31,6 +31,7 @@ def test_get_returns_objects_from_server_as_json(http_client, base_url):
     # Assert
     assert response.body == b'[{"object_name": "file_1.txt", "bucket_name": "bucket_1"}]'
 
+
 @pytest.mark.gen_test
 def test_get_returns_multiple_objects_as_a_json_array(http_client, base_url):
     # Arrange
@@ -50,6 +51,7 @@ def test_get_returns_multiple_objects_as_a_json_array(http_client, base_url):
     assert response.body == b'[{"object_name": "file_1.txt", "bucket_name": "bucket_1"},' \
                             b' {"object_name": "file_2.txt", "bucket_name": "bucket_2"}]'
 
+
 @pytest.mark.gen_test
 def test_get_returns_empty_aray_when_no_objects(http_client, base_url):
     # Arrange
@@ -58,4 +60,3 @@ def test_get_returns_empty_aray_when_no_objects(http_client, base_url):
     response = yield http_client.fetch(base_url)
     # Assert
     assert response.body == b'[]'
-

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -21,11 +21,18 @@ class DataReplicationServiceTest(unittest.TestCase):
     def test_retrieve_objects_dicts_returns_all_correct_dictionaries_of_objects(self):
         # Arrange
         mock_object_1 = mock.create_autospec(Object)
-        mock_object_1.to_dict = {"object_name": "test", "bucket_name": "test_bucket", "is_dir": False, "size": 100,
-                             "etag": "test_etag", "last_modified": datetime.datetime(2018, 11, 1)}
+        mock_object_1.to_dict = {"object_name": "test",
+                                 "bucket_name": "test_bucket",
+                                 "is_dir": False,
+                                 "size": 100,
+                                 "etag": "test_etag",
+                                 "last_modified": datetime.datetime(2018, 11, 1)}
         mock_object_2 = mock.create_autospec(Object)
-        mock_object_2.to_dict = {"object_name": "test_2", "bucket_name": "test_bucket_2", "is_dir": False, "size": 100,
-                             "etag": "test_etag_2", "last_modified": datetime.datetime(2018, 11, 2)}
+        mock_object_2.to_dict = {"object_name": "test_2",
+                                 "bucket_name": "test_bucket_2",
+                                 "is_dir": False, "size": 100,
+                                 "etag": "test_etag_2",
+                                 "last_modified": datetime.datetime(2018, 11, 2)}
 
         self.mock_external_data_service.get_objects.return_value = [mock_object_1, mock_object_2]
         # Act
@@ -35,7 +42,6 @@ class DataReplicationServiceTest(unittest.TestCase):
                              "etag": "test_etag", "last_modified": datetime.datetime(2018, 11, 1)}
         assert output[1] == {"object_name": "test_2", "bucket_name": "test_bucket_2", "is_dir": False, "size": 100,
                              "etag": "test_etag_2", "last_modified": datetime.datetime(2018, 11, 2)}
-
 
     def test_retrieve_objects_dicts_empty_array_when_no_objects_present(self):
         self.mock_external_data_service.get_objects.return_value = []


### PR DESCRIPTION
Now that we have `runCodeAnalysis.sh` working, I've fixed all the `flake8` errors.

There's just one `pylint` error, which we can safely ignore: the `create_configuration` helper method in `configuration_test.py` has too many arguments.