### PR TITLE
Travis passes when PyLint score above 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
 script:
   - flake8 ./DittoWebApi
-  - pylint ./DittoWebApi
+  - python lint_threshold_check.py ./DittoWebApi
   - pytest ./DittoWebApi

--- a/ditto_web_api/lint_threshold_check.py
+++ b/ditto_web_api/lint_threshold_check.py
@@ -1,0 +1,15 @@
+import sys
+from pylint import lint
+
+THRESHOLD = 9.00
+
+if len(sys.argv) < 2:
+    raise Exception("Module to evaluate needs to be the first argument")
+
+run = lint.Run([sys.argv[1]], do_exit=False)
+score = run.linter.stats['global_note']
+
+if score < THRESHOLD:
+    print("exit code = 1")
+    sys.exit(1)
+print("exit code = 0")

--- a/ditto_web_api/lint_threshold_check.py
+++ b/ditto_web_api/lint_threshold_check.py
@@ -13,3 +13,4 @@ if score < THRESHOLD:
     print("exit code = 1")
     sys.exit(1)
 print("exit code = 0")
+print("Passed with threshold level set at {}".format(THRESHOLD))


### PR DESCRIPTION
Fix travis build so that linting only fails below a threshold level of 9 rather than any linting errors.

To test:
* See that the file build correctly
* Try running script locally and change the threshold value to ensure fails and passes when it should