### PR TITLE
Feature/transfer only new files #5

### DIFF
--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -8,11 +8,11 @@ from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.configurations import Configuration
 from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHelper
-from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 
 
 def setup_logger(log_file_location, level):
@@ -47,10 +47,8 @@ if __name__ == "__main__":
     # Set up services
     EXTERNAL_DATA_SERVICE = ExternalDataService(CONFIGURATION)
     INTERNAL_DATA_SERVICE = InternalDataService(CONFIGURATION, FileSystemHelper(), LOGGER)
-    STORAGE_DIFFERENCE_PROCESSOR = StorageDifferenceProcessor()
     DATA_REPLICATION_SERVICE = DataReplicationService(EXTERNAL_DATA_SERVICE,
                                                       INTERNAL_DATA_SERVICE,
-                                                      STORAGE_DIFFERENCE_PROCESSOR,
                                                       LOGGER)
 
     # Launch app

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -6,6 +6,7 @@ from DittoWebApi.src.handlers.list_present import ListPresentHandler
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
+from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
@@ -53,6 +54,8 @@ if __name__ == "__main__":
         (r"/copydir/", CopyDirHandler, dict(data_replication_service=DATA_REPLICATION_SERVICE)),
         (r"/createbucket/", CreateBucketHandler, dict(data_replication_service=DATA_REPLICATION_SERVICE)),
         (r"/deletefile/", DeleteFileHandler, dict(data_replication_service=DATA_REPLICATION_SERVICE)),
+        (r"/copynew/", CopyNewHandler, dict(data_replication_service=DATA_REPLICATION_SERVICE)),
+
     ])
     APP.listen(8888)
     tornado.ioloop.IOLoop.current().start()

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -12,6 +12,7 @@ from DittoWebApi.src.services.external.external_data_service import ExternalData
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.configurations import Configuration
 from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHelper
+from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 
 
 def setup_logger(log_file_location, level):
@@ -46,7 +47,11 @@ if __name__ == "__main__":
     # Set up services
     EXTERNAL_DATA_SERVICE = ExternalDataService(CONFIGURATION)
     INTERNAL_DATA_SERVICE = InternalDataService(CONFIGURATION, FileSystemHelper(), LOGGER)
-    DATA_REPLICATION_SERVICE = DataReplicationService(EXTERNAL_DATA_SERVICE, INTERNAL_DATA_SERVICE, LOGGER)
+    STORAGE_DIFFERENCE_PROCESSOR = StorageDifferenceProcessor()
+    DATA_REPLICATION_SERVICE = DataReplicationService(EXTERNAL_DATA_SERVICE,
+                                                      INTERNAL_DATA_SERVICE,
+                                                      STORAGE_DIFFERENCE_PROCESSOR,
+                                                      LOGGER)
 
     # Launch app
     APP = tornado.web.Application([

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -8,7 +8,6 @@ from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
-from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.configurations import Configuration

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -6,7 +6,7 @@ from DittoWebApi.src.handlers.list_present import ListPresentHandler
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.configurations import Configuration

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -8,6 +8,7 @@ from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.configurations import Configuration
@@ -46,8 +47,10 @@ if __name__ == "__main__":
     # Set up services
     EXTERNAL_DATA_SERVICE = ExternalDataService(CONFIGURATION)
     INTERNAL_DATA_SERVICE = InternalDataService(CONFIGURATION, FileSystemHelper(), LOGGER)
+    STORAGE_DIFFERENCE_PROCESSOR = StorageDifferenceProcessor()
     DATA_REPLICATION_SERVICE = DataReplicationService(EXTERNAL_DATA_SERVICE,
                                                       INTERNAL_DATA_SERVICE,
+                                                      STORAGE_DIFFERENCE_PROCESSOR,
                                                       LOGGER)
 
     # Launch app

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -1,0 +1,49 @@
+# pylint: disable=W0221,W0223
+from tornado_json.requesthandlers import APIHandler
+from tornado_json import schema
+
+
+class CopyNewHandler(APIHandler):
+    def initialize(self, data_replication_service):
+        self._data_replication_service = data_replication_service
+
+    @schema.validate(
+        input_schema={
+            "type": "object",
+            "properties": {
+                "bucket": {"type": "string"},
+                "directory": {"type": "string"},
+            },
+            "required": ["bucket"]
+        },
+        input_example={
+            "bucket": "test-bucket-name",
+            "directory": "testdir/testsubdir",
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"},
+                "new files transferred": {"type": "integer"},
+                "files updated": {"type": "integer"},
+                "files skipped": {"type": "integer"},
+                "data transferred (bytes)": {"type": "integer"},
+            }
+        },
+        output_example={
+            "type": "object",
+            "properties": {
+                "message": "Transfer successful",
+                "new files transferred": 1,
+                "files updated": 0,
+                "files skipped": 0,
+                "data transferred (bytes)": 1000,
+            }
+        },
+    )
+    def post(self, *args, **kwargs):
+        attrs = dict(self.body)
+        bucket_name = attrs["bucket"]
+        dir_path = attrs["directory"] if "directory" in attrs.keys() else None
+        result = self._data_replication_service.copy_new(bucket_name, dir_path)
+        return result

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -1,8 +1,8 @@
 from minio.error import InvalidBucketError
-from DittoWebApi.src.utils.return_helper import return_dict
+from DittoWebApi.src.utils.return_helper import return_transfer_summary
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
-from  DittoWebApi.src.utils import messages
+from DittoWebApi.src.utils import messages
 
 
 class DataReplicationService:
@@ -13,9 +13,9 @@ class DataReplicationService:
         self._logger = logger
 
     def _check_bucket_warning(self, bucket_name):
-            message = messages.bucket_existence_warning(bucket_name)
-            self._logger.warning(message)
-            return message
+        message = messages.bucket_existence_warning(bucket_name)
+        self._logger.warning(message)
+        return message
 
     def retrieve_object_dicts(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
@@ -30,27 +30,28 @@ class DataReplicationService:
 
     def copy_dir(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            return return_dict(message=self._check_bucket_warning(bucket_name))
+            return return_transfer_summary(message=self._check_bucket_warning(bucket_name))
         self._logger.debug("Copying for {}".format(dir_path))
         self._logger.info("Finding files in local directory")
         files_to_copy = self._internal_data_service.find_files(dir_path)
         if not files_to_copy:
             message = messages.no_files_found(dir_path)
             self._logger.warning(message)
-            return return_dict(message=message)
+            return return_transfer_summary(message=message)
         # route if files have been found
         if self._external_data_service.does_dir_exist(bucket_name, dir_path):
             skipped_files = len(files_to_copy)
             self._logger.warning(messages.directory_exists(dir_path, skipped_files))
-            return return_dict(files_skipped=skipped_files, message=messages.directory_exists(dir_path, skipped_files))
+            return return_transfer_summary(files_skipped=skipped_files,
+                                           message=messages.directory_exists(dir_path, skipped_files))
         # route if directory doesn't already exist
         self._logger.info("About to copy {} files".format(len(files_to_copy)))
         data_transferred = 0
         for processed_file in files_to_copy:
             data_transferred += self._external_data_service.upload_file(bucket_name, processed_file)
-        return return_dict(files_transferred=len(files_to_copy),
-                           data_transferred=data_transferred,
-                           message=messages.transfer_success())
+        return return_transfer_summary(files_transferred=len(files_to_copy),
+                                       data_transferred=data_transferred,
+                                       message=messages.transfer_success())
 
     def create_bucket(self, bucket_name):
         if not bucket_name:
@@ -58,7 +59,7 @@ class DataReplicationService:
             return return_bucket_message(messages.no_bucket_name())
         if not self._external_data_service.does_bucket_match_standard(bucket_name):
             self._logger.info(messages.bucket_breaks_config(bucket_name))
-            return return_bucket_message(messages.bucket_breaks_config(), bucket_name)
+            return return_bucket_message(messages.bucket_breaks_config(bucket_name), bucket_name)
         try:
             if self._external_data_service.does_bucket_exist(bucket_name):
                 self._logger.warning(messages.bucket_exists(bucket_name))
@@ -77,7 +78,7 @@ class DataReplicationService:
                                              bucket_name=bucket_name)
         if not self._external_data_service.does_object_exist(bucket_name, file_name):
             self._logger.warning(messages.file_existence_warning(file_name, bucket_name))
-            return return_delete_file_helper(message=messages.file_existence_warning(file_name,bucket_name),
+            return return_delete_file_helper(message=messages.file_existence_warning(file_name, bucket_name),
                                              file_name=file_name,
                                              bucket_name=bucket_name)
         self._external_data_service.delete_file(bucket_name, file_name)
@@ -86,18 +87,22 @@ class DataReplicationService:
 
     def copy_new(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            return return_dict(message=self._check_bucket_warning(bucket_name))
+            return return_transfer_summary(message=self._check_bucket_warning(bucket_name))
         directory = dir_path if dir_path else "root"
         self._logger.info("Finding files in {}".format(directory))
-        files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         files_in_directory = self._internal_data_service.find_files(dir_path)
+        if not files_in_directory:
+            self._logger.warning(messages.no_files_found(directory))
+            return return_transfer_summary(message=messages.no_files_found(directory))
+        files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
             len(files_in_directory), directory, bucket_name))
         files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket,
                                                                                 files_in_directory)
         if not files_to_transfer:
-            self._logger.warning(messages.no_files_found(directory))
-            return return_dict(message=messages.no_files_found(directory), files_skipped=len(files_in_directory))
+            self._logger.warning(messages.no_new_files(directory))
+            return return_transfer_summary(message=messages.no_new_files(directory),
+                                           files_skipped=len(files_in_directory))
         self._logger.info("About to transfer {} new files from {} into bucket {}".format(len(files_to_transfer),
                                                                                          directory,
                                                                                          bucket_name))
@@ -105,7 +110,7 @@ class DataReplicationService:
         for file in files_to_transfer:
             data_transferred += self._external_data_service.upload_file(bucket_name, file)
         self._logger.info(messages.transfer_summary(len(files_to_transfer), directory, data_transferred))
-        return return_dict(files_transferred=len(files_to_transfer),
-                           files_skipped=(len(files_in_directory)-len(files_to_transfer)),
-                           data_transferred=data_transferred,
-                           message=messages.transfer_success())
+        return return_transfer_summary(files_transferred=len(files_to_transfer),
+                                       files_skipped=(len(files_in_directory)-len(files_to_transfer)),
+                                       data_transferred=data_transferred,
+                                       message=messages.transfer_success())

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -13,7 +13,7 @@ class DataReplicationService:
 
     def retrieve_object_dicts(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage"
+            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
             self._logger.warning(message)
             return {"message": message}
         self._logger.info("Going to find objects from directory '{}' in bucket '{}'".format(dir_path, bucket_name))
@@ -26,7 +26,7 @@ class DataReplicationService:
 
     def copy_dir(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage"
+            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
             self._logger.warning(message)
             return return_dict(message=message)
         self._logger.debug("Copying for {}".format(dir_path))
@@ -75,7 +75,7 @@ class DataReplicationService:
 
     def try_delete_file(self, bucket_name, file_name):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage"
+            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
             self._logger.warning(message)
             return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
         if not self._external_data_service.does_object_exist(bucket_name, file_name):
@@ -88,7 +88,7 @@ class DataReplicationService:
 
     def copy_new(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage"
+            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
             self._logger.warning(message)
             return return_dict(message=message)
         directory = dir_path if dir_path else "root"

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -12,6 +12,10 @@ class DataReplicationService:
         self._logger = logger
 
     def retrieve_object_dicts(self, bucket_name, dir_path):
+        if not self._external_data_service.does_bucket_exist(bucket_name):
+            message = "Warning, bucket {} does not exist in the S3 storage"
+            self._logger.warning(message)
+            return {"message": message}
         self._logger.info("Going to find objects from directory '{}' in bucket '{}'".format(dir_path, bucket_name))
         objects = self._external_data_service.get_objects(bucket_name, dir_path)
         object_dicts = [obj.to_dict() for obj in objects]
@@ -70,13 +74,17 @@ class DataReplicationService:
         return return_bucket_message(message, bucket_name)
 
     def try_delete_file(self, bucket_name, file_name):
+        if not self._external_data_service.does_bucket_exist(bucket_name):
+            message = "Warning, bucket {} does not exist in the S3 storage"
+            self._logger.warning(message)
+            return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
         if not self._external_data_service.does_object_exist(bucket_name, file_name):
             message = "File {} does not exist in bucket {}".format(file_name, bucket_name)
             self._logger.warning(message)
-            return return_delete_file_helper(message, file_name, bucket_name)
+            return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
         self._external_data_service.delete_file(bucket_name, file_name)
         message = "File {} successfully deleted from bucket {}".format(file_name, bucket_name)
-        return return_delete_file_helper(message, file_name, bucket_name)
+        return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
 
     def copy_new(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -2,6 +2,7 @@ from minio.error import InvalidBucketError
 from DittoWebApi.src.utils.return_helper import return_dict
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
+from  DittoWebApi.src.utils import messages
 
 
 class DataReplicationService:
@@ -11,11 +12,14 @@ class DataReplicationService:
         self._storage_difference_processor = storage_difference_processor
         self._logger = logger
 
+    def _check_bucket_warning(self, bucket_name):
+            message = messages.bucket_existence_warning(bucket_name)
+            self._logger.warning(message)
+            return message
+
     def retrieve_object_dicts(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
-            self._logger.warning(message)
-            return {"message": message}
+            return {"message": self._check_bucket_warning(bucket_name)}
         self._logger.info("Going to find objects from directory '{}' in bucket '{}'".format(dir_path, bucket_name))
         objects = self._external_data_service.get_objects(bucket_name, dir_path)
         object_dicts = [obj.to_dict() for obj in objects]
@@ -26,71 +30,63 @@ class DataReplicationService:
 
     def copy_dir(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
-            self._logger.warning(message)
-            return return_dict(message=message)
+            return return_dict(message=self._check_bucket_warning(bucket_name))
         self._logger.debug("Copying for {}".format(dir_path))
         self._logger.info("Finding files in local directory")
         files_to_copy = self._internal_data_service.find_files(dir_path)
         if not files_to_copy:
-            message = "No files found in directory or directory does not exist ({})".format(dir_path)
+            message = messages.no_files_found(dir_path)
             self._logger.warning(message)
             return return_dict(message=message)
         # route if files have been found
         if self._external_data_service.does_dir_exist(bucket_name, dir_path):
             skipped_files = len(files_to_copy)
-            message = "Directory already exists, {} files skipped".format(skipped_files)
-            self._logger.warning(message)
-            return return_dict(files_skipped=skipped_files, message=message)
+            self._logger.warning(messages.directory_exists(dir_path, skipped_files))
+            return return_dict(files_skipped=skipped_files, message=messages.directory_exists(dir_path, skipped_files))
         # route if directory doesn't already exist
         self._logger.info("About to copy {} files".format(len(files_to_copy)))
         data_transferred = 0
         for processed_file in files_to_copy:
             data_transferred += self._external_data_service.upload_file(bucket_name, processed_file)
-        message = "Copied across {} files totaling {} bytes".format(len(files_to_copy), data_transferred)
-        return return_dict(files_transferred=len(files_to_copy), data_transferred=data_transferred, message=message)
+        return return_dict(files_transferred=len(files_to_copy),
+                           data_transferred=data_transferred,
+                           message=messages.transfer_success())
 
     def create_bucket(self, bucket_name):
         if not bucket_name:
-            message = "No bucket name provided"
-            self._logger.warning(message)
-            return return_bucket_message(message)
+            self._logger.warning(messages.no_bucket_name())
+            return return_bucket_message(messages.no_bucket_name())
         if not self._external_data_service.does_bucket_match_standard(bucket_name):
-            message = "Bucket breaks local naming standard ({})".format(bucket_name)
-            self._logger.info(message)
-            return return_bucket_message(message, bucket_name)
+            self._logger.info(messages.bucket_breaks_config(bucket_name))
+            return return_bucket_message(messages.bucket_breaks_config(), bucket_name)
         try:
             if self._external_data_service.does_bucket_exist(bucket_name):
-                message = "Bucket already exists ({})".format(bucket_name)
-                self._logger.warning(message)
-                return return_bucket_message(message, bucket_name)
+                self._logger.warning(messages.bucket_exists(bucket_name))
+                return return_bucket_message(messages.bucket_exists(bucket_name), bucket_name)
         except InvalidBucketError:
-            message = "Bucket name breaks S3 ({})".format(bucket_name)
-            self._logger.warning(message)
-            return return_bucket_message(message, bucket_name)
+            self._logger.warning(messages.bucket_breaks_s3_convention(bucket_name))
+            return return_bucket_message(messages.bucket_breaks_s3_convention(bucket_name), bucket_name)
         self._external_data_service.create_bucket(bucket_name)
-        message = "Bucket Created ({})".format(bucket_name)
-        self._logger.info(message)
-        return return_bucket_message(message, bucket_name)
+        self._logger.info(messages.bucket_created(bucket_name))
+        return return_bucket_message(messages.bucket_created(bucket_name), bucket_name)
 
     def try_delete_file(self, bucket_name, file_name):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
-            self._logger.warning(message)
-            return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
+            return return_delete_file_helper(message=self._check_bucket_warning(bucket_name),
+                                             file_name=file_name,
+                                             bucket_name=bucket_name)
         if not self._external_data_service.does_object_exist(bucket_name, file_name):
-            message = "File {} does not exist in bucket {}".format(file_name, bucket_name)
-            self._logger.warning(message)
-            return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
+            self._logger.warning(messages.file_existence_warning(file_name, bucket_name))
+            return return_delete_file_helper(message=messages.file_existence_warning(file_name,bucket_name),
+                                             file_name=file_name,
+                                             bucket_name=bucket_name)
         self._external_data_service.delete_file(bucket_name, file_name)
-        message = "File {} successfully deleted from bucket {}".format(file_name, bucket_name)
+        message = messages.file_deleted(file_name, bucket_name)
         return return_delete_file_helper(message=message, file_name=file_name, bucket_name=bucket_name)
 
     def copy_new(self, bucket_name, dir_path):
         if not self._external_data_service.does_bucket_exist(bucket_name):
-            message = "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
-            self._logger.warning(message)
-            return return_dict(message=message)
+            return return_dict(message=self._check_bucket_warning(bucket_name))
         directory = dir_path if dir_path else "root"
         self._logger.info("Finding files in {}".format(directory))
         files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
@@ -100,20 +96,16 @@ class DataReplicationService:
         files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket,
                                                                                 files_in_directory)
         if not files_to_transfer:
-            message = "No new files found in directory or directory does not exist ({})".format(directory)
-            self._logger.warning(message)
-            return return_dict(message=message, files_skipped=len(files_in_directory))
+            self._logger.warning(messages.no_files_found(directory))
+            return return_dict(message=messages.no_files_found(directory), files_skipped=len(files_in_directory))
         self._logger.info("About to transfer {} new files from {} into bucket {}".format(len(files_to_transfer),
                                                                                          directory,
                                                                                          bucket_name))
         data_transferred = 0
         for file in files_to_transfer:
             data_transferred += self._external_data_service.upload_file(bucket_name, file)
-        message = "Transfer successful, copied {} new files from {} totalling {} bytes".format(len(files_to_transfer),
-                                                                                               directory,
-                                                                                               data_transferred)
-        self._logger.info(message)
+        self._logger.info(messages.transfer_summary(len(files_to_transfer), directory, data_transferred))
         return return_dict(files_transferred=len(files_to_transfer),
                            files_skipped=(len(files_in_directory)-len(files_to_transfer)),
                            data_transferred=data_transferred,
-                           message=message)
+                           message=messages.transfer_success())

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -84,7 +84,7 @@ class DataReplicationService:
         files_in_directory = self._internal_data_service.find_files(dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
             len(files_in_directory), directory, bucket_name))
-        files_to_transfer = self._storage_difference_processor.new_files(files_already_in_bucket, files_in_directory)
+        files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket, files_in_directory)
         data_transferred = 0
         if not files_to_transfer:
             message = "No new files found in directory or directory does not exist ({})".format(directory)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -2,13 +2,13 @@ from minio.error import InvalidBucketError
 from DittoWebApi.src.utils.return_helper import return_dict
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
+from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 
 
 class DataReplicationService:
-    def __init__(self, external_data_service, internal_data_service, storage_difference_processor, logger):
+    def __init__(self, external_data_service, internal_data_service, logger):
         self._external_data_service = external_data_service
         self._internal_data_service = internal_data_service
-        self._storage_difference_processor = storage_difference_processor
         self._logger = logger
 
     def retrieve_object_dicts(self, bucket_name, dir_path):
@@ -75,18 +75,15 @@ class DataReplicationService:
         return return_delete_file_helper(message, file_name, bucket_name)
 
     def copy_new(self, bucket_name, dir_path):
-        if dir_path:
-            directory = dir_path
-        else:
-            directory = "root"
+        directory = dir_path if dir_path else "root"
         self._logger.info("Finding files in {}".format(directory))
         files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         files_in_directory = self._internal_data_service.find_files(dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
             len(files_in_directory), directory, bucket_name))
-        files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket,
-                                                                                files_in_directory)
-        data_transferred = 0
+        storage_difference_processor = StorageDifferenceProcessor()
+        files_to_transfer = storage_difference_processor.return_new_files(files_already_in_bucket,
+                                                                          files_in_directory)
         if not files_to_transfer:
             message = "No new files found in directory or directory does not exist ({})".format(directory)
             self._logger.warning(message)
@@ -94,6 +91,7 @@ class DataReplicationService:
         self._logger.info("About to transfer {} new files from {} into bucket {}".format(len(files_to_transfer),
                                                                                          directory,
                                                                                          bucket_name))
+        data_transferred = 0
         for file in files_to_transfer:
             data_transferred += self._external_data_service.upload_file(bucket_name, file)
         message = "Transfer successful, copied {} new files from {} totalling {} bytes".format(len(files_to_transfer),

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -2,13 +2,13 @@ from minio.error import InvalidBucketError
 from DittoWebApi.src.utils.return_helper import return_dict
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
-from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
 
 
 class DataReplicationService:
-    def __init__(self, external_data_service, internal_data_service, logger):
+    def __init__(self, external_data_service, internal_data_service, storage_difference_processor, logger):
         self._external_data_service = external_data_service
         self._internal_data_service = internal_data_service
+        self._storage_difference_processor = storage_difference_processor
         self._logger = logger
 
     def retrieve_object_dicts(self, bucket_name, dir_path):
@@ -81,9 +81,8 @@ class DataReplicationService:
         files_in_directory = self._internal_data_service.find_files(dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
             len(files_in_directory), directory, bucket_name))
-        storage_difference_processor = StorageDifferenceProcessor()
-        files_to_transfer = storage_difference_processor.return_new_files(files_already_in_bucket,
-                                                                          files_in_directory)
+        files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket,
+                                                                                files_in_directory)
         if not files_to_transfer:
             message = "No new files found in directory or directory does not exist ({})".format(directory)
             self._logger.warning(message)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -84,7 +84,8 @@ class DataReplicationService:
         files_in_directory = self._internal_data_service.find_files(dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
             len(files_in_directory), directory, bucket_name))
-        files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket, files_in_directory)
+        files_to_transfer = self._storage_difference_processor.return_new_files(files_already_in_bucket,
+                                                                                files_in_directory)
         data_transferred = 0
         if not files_to_transfer:
             message = "No new files found in directory or directory does not exist ({})".format(directory)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -21,6 +21,10 @@ class DataReplicationService:
         return object_dicts
 
     def copy_dir(self, bucket_name, dir_path):
+        if not self._external_data_service.does_bucket_exist(bucket_name):
+            message = "Warning, bucket {} does not exist in the S3 storage"
+            self._logger.warning(message)
+            return return_dict(message=message)
         self._logger.debug("Copying for {}".format(dir_path))
         self._logger.info("Finding files in local directory")
         files_to_copy = self._internal_data_service.find_files(dir_path)
@@ -75,6 +79,10 @@ class DataReplicationService:
         return return_delete_file_helper(message, file_name, bucket_name)
 
     def copy_new(self, bucket_name, dir_path):
+        if not self._external_data_service.does_bucket_exist(bucket_name):
+            message = "Warning, bucket {} does not exist in the S3 storage"
+            self._logger.warning(message)
+            return return_dict(message=message)
         directory = dir_path if dir_path else "root"
         self._logger.info("Finding files in {}".format(directory))
         files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -83,8 +83,7 @@ class DataReplicationService:
         files_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         files_in_directory = self._internal_data_service.find_files(dir_path)
         self._logger.info("Found {} files in {} comparing against files already in bucket {}".format(
-            len(files_in_directory), directory, bucket_name)
-        )
+            len(files_in_directory), directory, bucket_name))
         files_to_transfer = self._storage_difference_processor.new_files(files_already_in_bucket, files_in_directory)
         data_transferred = 0
         if not files_to_transfer:

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -1,8 +1,21 @@
-def new_files(files_in_bucket, files_in_directory):
-    names_of_files_in_bucket = [file.file_name for file in files_in_bucket]
-    list_of_new_files = [file_information_object
-                         for file_information_object
-                         in files_in_directory
-                         if file_information_object.file_name
-                         not in names_of_files_in_bucket]
-    return list_of_new_files
+class StorageDifferenceProcessor:
+
+    def new_files(self, objects_in_bucket, files_in_directory):
+        list_of_new_files = []
+        if not objects_in_bucket:
+            return files_in_directory
+        objects_to_check = [s3_obj for s3_obj in objects_in_bucket]
+        for file_information in files_in_directory:
+            if not objects_to_check:
+                list_of_new_files.append(file_information)
+            else:
+                matches = [self.are_the_same(s3_object, file_information) for s3_object in objects_to_check]
+                if not any(matches):
+                    list_of_new_files.append(file_information)
+                else:
+                    del objects_to_check[matches.index(True)]
+        return list_of_new_files
+
+    def are_the_same(self, s3_object, file_information):
+        s3_object_name = s3_object.object_name
+        return file_information.rel_path == s3_object_name

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -1,0 +1,8 @@
+def new_files(files_in_bucket, files_in_directory):
+    names_of_files_in_bucket = [file.file_name for file in files_in_bucket]
+    list_of_new_files = [file_information_object
+                         for file_information_object
+                         in files_in_directory
+                         if file_information_object.file_name
+                         not in names_of_files_in_bucket]
+    return list_of_new_files

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -10,14 +10,16 @@ class StorageDifferenceProcessor:
             return files_in_directory
         objects_to_check = [s3_obj for s3_obj in objects_in_bucket]
         for file_information in files_in_directory:
-            if not objects_to_check:
-                list_of_new_files.append(file_information)
-            else:
+            if objects_to_check:
                 matches = [self.are_the_same(s3_object, file_information) for s3_object in objects_to_check]
                 if not any(matches):
                     list_of_new_files.append(file_information)
                 else:
                     del objects_to_check[matches.index(True)]
+                files_in_directory.remove(file_information)
+            else:
+                list_of_new_files += files_in_directory
+                break
         return list_of_new_files
 
     @staticmethod

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -1,7 +1,7 @@
 # pylint: disable=R0201
 class StorageDifferenceProcessor:
 
-    def new_files(self, objects_in_bucket, files_in_directory):
+    def return_new_files(self, objects_in_bucket, files_in_directory):
         list_of_new_files = []
         if not objects_in_bucket:
             return files_in_directory

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -1,3 +1,4 @@
+# pylint: disable=R0201
 class StorageDifferenceProcessor:
 
     def new_files(self, objects_in_bucket, files_in_directory):

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -17,6 +17,7 @@ class StorageDifferenceProcessor:
                     del objects_to_check[matches.index(True)]
         return list_of_new_files
 
-    def are_the_same(self, s3_object, file_information):
+    @staticmethod
+    def are_the_same(s3_object, file_information):
         s3_object_name = s3_object.object_name
         return file_information.rel_path == s3_object_name

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/storage_difference_processor.py
@@ -1,4 +1,7 @@
 # pylint: disable=R0201
+from DittoWebApi.src.utils.file_system.path_helpers import to_posix
+
+
 class StorageDifferenceProcessor:
 
     def return_new_files(self, objects_in_bucket, files_in_directory):
@@ -20,4 +23,4 @@ class StorageDifferenceProcessor:
     @staticmethod
     def are_the_same(s3_object, file_information):
         s3_object_name = s3_object.object_name
-        return file_information.rel_path == s3_object_name
+        return to_posix(file_information.rel_path) == to_posix(s3_object_name)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication_service.py
@@ -72,3 +72,6 @@ class DataReplicationService:
         self._external_data_service.delete_file(bucket_name, file_name)
         message = "File {} successfully deleted from bucket {}".format(file_name, bucket_name)
         return return_delete_file_helper(message, file_name, bucket_name)
+
+    def copy_new(self, bucket_name, dir_path):
+        pass

--- a/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
@@ -14,12 +14,10 @@ class ExternalDataService:
     def get_buckets(self):
         return [BucketInformation(bucket) for bucket in self._s3_client.list_buckets()]
 
-    def get_objects(self, bucket_names, dir_path):
+    def get_objects(self, bucket_name, dir_path):
         """Passes list of object of Objects up to data replication service"""
-        objs = []
-        for bucket_name in bucket_names:
-            objects = self._s3_client.list_objects(bucket_name, dir_path, recursive=True)
-            objs += [S3ObjectInformation(obj) for obj in objects if not obj.is_dir]
+        objects = self._s3_client.list_objects(bucket_name, dir_path, recursive=True)
+        objs = [S3ObjectInformation(obj) for obj in objects if not obj.is_dir]
         return objs
 
     def does_dir_exist(self, bucket, dir_path):

--- a/ditto_web_api/DittoWebApi/src/utils/file_system/path_helpers.py
+++ b/ditto_web_api/DittoWebApi/src/utils/file_system/path_helpers.py
@@ -1,5 +1,5 @@
-from pathlib import Path
+from pathlib import PureWindowsPath
 
 
 def to_posix(path):
-    return Path(path).as_posix()
+    return PureWindowsPath(path).as_posix()

--- a/ditto_web_api/DittoWebApi/src/utils/messages.py
+++ b/ditto_web_api/DittoWebApi/src/utils/messages.py
@@ -1,0 +1,48 @@
+def bucket_existence_warning(bucket_name):
+    return "Warning, bucket {} does not exist in the S3 storage".format(bucket_name)
+
+
+def no_files_found(dir_path):
+    return "No files found in directory or directory does not exist ({})".format(dir_path)
+
+
+def transfer_success():
+    return "Transfer successful"
+
+
+def transfer_summary(files_to_tansfer , directory, data_transferred):
+    return "Transfer successful, copied {} new files from {} totalling {} bytes".format(files_to_tansfer,
+                                                                                        directory,
+                                                                                        data_transferred)
+
+
+def file_deleted(file_name, bucket_name):
+    return "File {} successfully deleted from bucket {}".format(file_name, bucket_name)
+
+
+def bucket_created(bucket_name):
+    return "Bucket Created ({})".format(bucket_name)
+
+
+def file_existence_warning(file_name, bucket_name):
+    return "File {} does not exist in bucket {}".format(file_name, bucket_name)
+
+
+def no_bucket_name():
+    return "No bucket name provided"
+
+
+def bucket_breaks_config(bucket_name):
+    return "Bucket breaks local naming standard ({})".format(bucket_name)
+
+
+def bucket_breaks_s3_convention(bucket_name):
+    return "Bucket name breaks S3 ({})".format(bucket_name)
+
+
+def directory_exists(directory, skipped_files):
+    return "Directory {} already exists on S3, {} files skipped".format(directory, skipped_files)
+
+
+def bucket_exists(bucket_name):
+    return "Bucket already exists ({})".format(bucket_name)

--- a/ditto_web_api/DittoWebApi/src/utils/messages.py
+++ b/ditto_web_api/DittoWebApi/src/utils/messages.py
@@ -6,11 +6,15 @@ def no_files_found(dir_path):
     return "No files found in directory or directory does not exist ({})".format(dir_path)
 
 
+def no_new_files(dir_path):
+    return "No new files found in directory ({})".format(dir_path)
+
+
 def transfer_success():
     return "Transfer successful"
 
 
-def transfer_summary(files_to_tansfer , directory, data_transferred):
+def transfer_summary(files_to_tansfer, directory, data_transferred):
     return "Transfer successful, copied {} new files from {} totalling {} bytes".format(files_to_tansfer,
                                                                                         directory,
                                                                                         data_transferred)

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -1,17 +1,17 @@
 def return_dict(files_transferred=0, files_updated=0, files_skipped=0, data_transferred=0, message=""):
-    return {"Message": message,
-            "Files transferred": files_transferred,
-            "Files updated": files_updated,
-            "Files skipped": files_skipped,
-            "Data transferred (bytes)": data_transferred}
+    return {"message": message,
+            "new files transferred": files_transferred,
+            "files updated": files_updated,
+            "files skipped": files_skipped,
+            "data transferred (bytes)": data_transferred}
 
 
 def return_bucket_message(message, bucket_name=""):
-    return {"Message": message,
-            "Bucket": bucket_name}
+    return {"message": message,
+            "bucket": bucket_name}
 
 
 def return_delete_file_helper(message, file_name, bucket_name):
-    return {"Message": message,
-            "File": file_name,
-            "Bucket": bucket_name}
+    return {"message": message,
+            "file": file_name,
+            "bucket": bucket_name}

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -1,6 +1,6 @@
-def return_dict(files_transferred=0, files_updated=0, files_skipped=0, data_transferred=0, message=""):
+def return_transfer_summary(files_transferred=0, files_updated=0, files_skipped=0, data_transferred=0, message=""):
     return {"message": message,
-            "new files transferred": files_transferred,
+            "new files uploaded": files_transferred,
             "files updated": files_updated,
             "files skipped": files_skipped,
             "data transferred (bytes)": data_transferred}

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -4,7 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
-from DittoWebApi.src.utils.return_helper import return_dict
+from DittoWebApi.src.utils.return_helper import return_transfer_summary
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -21,7 +21,11 @@ def app():
 @pytest.mark.gen_test
 def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_dict(1, 0, 0, 100, "Transfer successful")
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Transfer successful",
+                                                           "new files uploaded": 1,
+                                                           "files updated": 0,
+                                                           "files skipped": 0,
+                                                           "data transferred (bytes)": 100}
     # Act
     url = base_url + "/copydir/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory/some_sub_dir"})
@@ -30,7 +34,25 @@ def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, b
     response_body = json.loads(response.body, encoding='utf-8')
     assert response_body["status"] == "success"
     assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files transferred': 1,
+                                     'new files uploaded': 1,
+                                     'files updated': 0,
+                                     'files skipped': 0,
+                                     'data transferred (bytes)': 100}
+
+
+@pytest.mark.gen_test
+def test_post_has_coupling_with_return_handler(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_transfer_summary(1, 0, 0, 100, "Transfer successful")
+    # Act
+    url = base_url + "/copydir/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory/some_sub_dir"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Transfer successful',
+                                     'new files uploaded': 1,
                                      'files updated': 0,
                                      'files skipped': 0,
                                      'data transferred (bytes)': 100}
@@ -39,11 +61,11 @@ def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, b
 @pytest.mark.gen_test
 def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_dict(0,
-                                                                      0,
-                                                                      5,
-                                                                      0,
-                                                                      "Directory already exists, 5 files skipped")
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Directory already exists, 5 files skipped",
+                                                           "new files uploaded": 0,
+                                                           "files updated": 0,
+                                                           "files skipped": 5,
+                                                           "data transferred (bytes)": 0}
     # Act
     url = base_url + "/copydir/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
@@ -52,7 +74,27 @@ def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     response_body = json.loads(response.body, encoding='utf-8')
     assert response_body["status"] == "success"
     assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
-                                     'new files transferred': 0,
+                                     'new files uploaded': 0,
+                                     'files updated': 0,
+                                     'files skipped': 5,
+                                     'data transferred (bytes)': 0}
+
+
+@pytest.mark.gen_test
+def test_post_returns_summary_of_failed_transfer_as_json_with_return_helper_coupling(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_transfer_summary(
+        0, 0, 5, 0, "Directory already exists, 5 files skipped"
+    )
+    # Act
+    url = base_url + "/copydir/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
+                                     'new files uploaded': 0,
                                      'files updated': 0,
                                      'files skipped': 5,
                                      'data transferred (bytes)': 0}

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -4,6 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
+from DittoWebApi.src.utils.return_helper import return_dict
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -20,14 +21,10 @@ def app():
 @pytest.mark.gen_test
 def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Transfer successful",
-                                                           "new files transferred": 1,
-                                                           "files updated": 0,
-                                                           "files skipped": 0,
-                                                           "data transferred (bytes)": 100}
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_dict(1, 0, 0, 100, "Transfer successful")
     # Act
     url = base_url + "/copydir/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory/some_sub_dir"})
     response = yield http_client.fetch(url, method="POST", body=body)
     # Assert
     response_body = json.loads(response.body, encoding='utf-8')
@@ -42,11 +39,11 @@ def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, b
 @pytest.mark.gen_test
 def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Directory already exists, 5 files skipped",
-                                                           "new files transferred": 0,
-                                                           "files updated": 0,
-                                                           "files skipped": 5,
-                                                           "data transferred (bytes)": 0}
+    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_dict(0,
+                                                                      0,
+                                                                      5,
+                                                                      0,
+                                                                      "Directory already exists, 5 files skipped")
     # Act
     url = base_url + "/copydir/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -2,7 +2,7 @@ import json
 import mock
 import pytest
 import tornado.web
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -4,6 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
+from DittoWebApi.src.utils.return_helper import return_dict
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -20,11 +21,7 @@ def app():
 @pytest.mark.gen_test
 def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {"message": "Transfer successful",
-                                                           "new files transferred": 1,
-                                                           "files updated": 0,
-                                                           "files skipped": 3,
-                                                           "data transferred (bytes)": 100}
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_dict(1, 0, 3, 100, "Transfer successful")
     # Act
     url = base_url + "/copynew/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
@@ -42,11 +39,11 @@ def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, b
 @pytest.mark.gen_test
 def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {"message": "Directory already exists, 5 files skipped",
-                                                           "new files transferred": 0,
-                                                           "files updated": 0,
-                                                           "files skipped": 5,
-                                                           "data transferred (bytes)": 0}
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_dict(0,
+                                                                      0,
+                                                                      5,
+                                                                      0,
+                                                                      "Directory already exists, 5 files skipped")
     # Act
     url = base_url + "/copynew/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -4,7 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
-from DittoWebApi.src.utils.return_helper import return_dict
+from DittoWebApi.src.utils.return_helper import return_transfer_summary
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -21,7 +21,11 @@ def app():
 @pytest.mark.gen_test
 def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_dict(1, 0, 3, 100, "Transfer successful")
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {'message': 'Transfer successful',
+                                                           'new files transferred': 1,
+                                                           'files updated': 0,
+                                                           'files skipped': 3,
+                                                           'data transferred (bytes)': 100}
     # Act
     url = base_url + "/copynew/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
@@ -37,13 +41,37 @@ def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, b
 
 
 @pytest.mark.gen_test
+def test_post_returns_summary_of_transfer_as_json_when_successful_with_return_handler_coupling(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_transfer_summary(
+        message='Transfer successful',
+        files_transferred=1,
+        files_updated=0,
+        files_skipped=3,
+        data_transferred=100
+    )
+    # Act
+    url = base_url + "/copynew/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Transfer successful',
+                                     'new files uploaded': 1,
+                                     'files updated': 0,
+                                     'files skipped': 3,
+                                     'data transferred (bytes)': 100}
+
+
+@pytest.mark.gen_test
 def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_dict(0,
-                                                                      0,
-                                                                      5,
-                                                                      0,
-                                                                      "Directory already exists, 5 files skipped")
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {'message': "Directory already exists, 5 files skipped",
+                                                           'new files transferred': 0,
+                                                           'files updated': 0,
+                                                           'files skipped': 5,
+                                                           'data transferred (bytes)': 0}
     # Act
     url = base_url + "/copynew/"
     body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
@@ -53,6 +81,30 @@ def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
     assert response_body["status"] == "success"
     assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
                                      'new files transferred': 0,
+                                     'files updated': 0,
+                                     'files skipped': 5,
+                                     'data transferred (bytes)': 0}
+
+
+@pytest.mark.gen_test
+def test_post_returns_summary_of_failed_transfer_as_json_with_coupling_return_handler(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_transfer_summary(
+        message="Directory already exists, 5 files skipped",
+        files_transferred=0,
+        files_updated=0,
+        files_skipped=5,
+        data_transferred=0
+    )
+    # Act
+    url = base_url + "/copynew/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
+                                     'new files uploaded': 0,
                                      'files updated': 0,
                                      'files skipped': 5,
                                      'data transferred (bytes)': 0}

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -1,0 +1,61 @@
+import json
+import mock
+import pytest
+import tornado.web
+from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.handlers.copy_new import CopyNewHandler
+
+
+MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+
+
+@pytest.fixture(autouse=True)
+def app():
+    application = tornado.web.Application([
+        (r"/copynew/", CopyNewHandler, dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE))
+    ])
+    return application
+
+
+@pytest.mark.gen_test
+def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {"message": "Transfer successful",
+                                                           "new files transferred": 1,
+                                                           "files updated": 0,
+                                                           "files skipped": 3,
+                                                           "data transferred (bytes)": 100}
+    # Act
+    url = base_url + "/copynew/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Transfer successful',
+                                     'new files transferred': 1,
+                                     'files updated': 0,
+                                     'files skipped': 3,
+                                     'data transferred (bytes)': 100}
+
+
+@pytest.mark.gen_test
+def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
+    # Arrange
+    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {"message": "Directory already exists, 5 files skipped",
+                                                           "new files transferred": 0,
+                                                           "files updated": 0,
+                                                           "files skipped": 5,
+                                                           "data transferred (bytes)": 0}
+    # Act
+    url = base_url + "/copynew/"
+    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
+    response = yield http_client.fetch(url, method="POST", body=body)
+    # Assert
+    response_body = json.loads(response.body, encoding='utf-8')
+    assert response_body["status"] == "success"
+    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
+                                     'new files transferred': 0,
+                                     'files updated': 0,
+                                     'files skipped': 5,
+                                     'data transferred (bytes)': 0}

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -2,7 +2,7 @@ import json
 import mock
 import pytest
 import tornado.web
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -4,6 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
+from DittoWebApi.src.utils.return_helper import return_bucket_message
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -20,8 +21,8 @@ def app():
 @pytest.mark.gen_test
 def test_create_bucket_returns_summary_of_new_bucket_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = {"message": "Bucket Created (some-bucket)",
-                                                                "bucket": "some-bucket"}
+    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = return_bucket_message("Bucket Created (some-bucket)",
+                                                                                     "some-bucket")
     # Act
     url = base_url + "/createbucket/"
     body = json.dumps({'bucket': "bucket_1"})
@@ -36,8 +37,9 @@ def test_create_bucket_returns_summary_of_new_bucket_when_successful(http_client
 @pytest.mark.gen_test
 def test_create_bucket_returns_summary_of_failure_when_bucket_already_exists(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = {"message": "Bucket already exists (some-bucket)",
-                                                                "bucket": "some-bucket"}
+    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = return_bucket_message(
+        "Bucket already exists (some-bucket)", "some-bucket"
+    )
     # Act
     url = base_url + "/createbucket/"
     body = json.dumps({'bucket': "bucket_1"})

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -2,7 +2,7 @@ import json
 import mock
 import pytest
 import tornado.web
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -4,6 +4,7 @@ import pytest
 import tornado.web
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
+from DittoWebApi.src.utils.return_helper import return_delete_file_helper
 
 
 MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
@@ -20,10 +21,9 @@ def app():
 @pytest.mark.gen_test
 def test_delete_returns_summary_of_deleted_files_as_json_when_successful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = {"message": "File some_file.txt, successfully deleted"
-                                                                             " from bucket bucket_1",
-                                                                  "file": "some_file.txt",
-                                                                  "bucket": "bucket_1"}
+    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = return_delete_file_helper(
+        "File some_file.txt, successfully deleted from bucket bucket_1", "some_file.txt", "bucket_1"
+    )
     # Act
     url = base_url + "/deletefile/"
     body = json.dumps({'bucket': "bucket_1", 'file': "some_file.txt"})
@@ -39,10 +39,9 @@ def test_delete_returns_summary_of_deleted_files_as_json_when_successful(http_cl
 @pytest.mark.gen_test
 def test_delete_returns_summary_of_failed_delete_as_json_when_unsuccessful(http_client, base_url):
     # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = {"message": "File some_file.txt does not exist in "
-                                                                             "bucket bucket_1",
-                                                                  "file": "some_file.txt",
-                                                                  "bucket": "bucket_1"}
+    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = return_delete_file_helper(
+        "File some_file.txt does not exist in bucket bucket_1", "some_file.txt", "bucket_1"
+    )
     # Act
     url = base_url + "/deletefile/"
     body = json.dumps({'bucket': "bucket_1", 'file': "some_file.txt"})

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -2,7 +2,7 @@ import json
 import mock
 import pytest
 import tornado.web
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
@@ -2,7 +2,7 @@ import json
 import mock
 import pytest
 import tornado.web
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.handlers.list_present import ListPresentHandler
 
 

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from DittoWebApi.src.models.file_information import FileInformation
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
-from DittoWebApi.src.services.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
 from DittoWebApi.src.models.bucket_information import BucketInformation

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -12,6 +12,8 @@ from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
 from DittoWebApi.src.models.bucket_information import BucketInformation
 from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
+from DittoWebApi.src.utils.return_helper import return_dict
+from DittoWebApi.src.utils.return_helper import return_delete_file_helper
 
 
 class DataReplicationServiceTest(unittest.TestCase):
@@ -54,8 +56,18 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_file_information_3 = mock.create_autospec(FileInformation)
         self.mock_file_information_3.rel_path = "test_dir/test"
 
+    def test_retrieve_objects_dicts_returns_warning_when_bucket_does_not_exist(self):
+        # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = False
+        # Act
+        output = self.test_service.retrieve_object_dicts("test_bucket", None)
+        # Assert
+        assert self.mock_external_data_service.get_objects.call_count == 0
+        assert output == {"message": "Warning, bucket test_bucket does not exist in the S3 storage"}
+
     def test_retrieve_objects_dicts_returns_all_correct_dictionaries_of_objects(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1, self.mock_object_2]
         # Act
         output = self.test_service.retrieve_object_dicts("test_bucket", None)
@@ -75,6 +87,7 @@ class DataReplicationServiceTest(unittest.TestCase):
         assert len(output) == 2
 
     def test_retrieve_objects_dicts_empty_array_when_no_objects_present(self):
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.get_objects.return_value = []
         # Act
         output = self.test_service.retrieve_object_dicts("test_bucket", None)
@@ -83,6 +96,7 @@ class DataReplicationServiceTest(unittest.TestCase):
         assert output == []
 
     def test_retrieve_objects_dicts_returns_all_correct_dictionaries_of_objects_from_sub_dir(self):
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         # Arrange
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_3]
         # Act
@@ -97,7 +111,7 @@ class DataReplicationServiceTest(unittest.TestCase):
                              "last_modified": 2132142421.123123}
         assert len(output) == 1
 
-    def test_return_bucket_message_correct_when_bucket_name_invalid(self):
+    def test_create_bucket_message_correct_when_bucket_name_invalid(self):
         # Arrange
         self.mock_external_data_service.does_bucket_match_standard.return_value = False
         bucket_name = "test-1234-"
@@ -142,18 +156,34 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.assertEqual(response, {"message": "Bucket Created (test-12345)",
                                     "bucket": "test-12345"})
 
+    def test_copy_dir_returns_warning_if_bucket_does_not_exist(self):
+        # Arrange
+        bucket_name = 'test-12345'
+        dir_path = 'testdir/testsubdir/'
+        self.mock_external_data_service.does_bucket_exist.return_value = False
+        # Act
+        response = self.test_service.copy_dir(bucket_name, dir_path)
+        # Assert
+        self.mock_external_data_service.upload_file.assert_not_called()
+        assert response == return_dict(message='Warning, bucket test-12345 does not exist in the S3 storage')
+
     def test_copy_dir_does_not_upload_if_no_local_files_found(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         bucket_name = 'test-12345'
         dir_path = 'testdir/testsubdir/'
         self.mock_internal_data_service.find_files.return_value = []
         # Act
-        self.test_service.copy_dir(bucket_name, dir_path)
+        response = self.test_service.copy_dir(bucket_name, dir_path)
         # Assert
         self.mock_external_data_service.upload_file.assert_not_called()
+        assert response == return_dict(
+            message='No files found in directory or directory does not exist (testdir/testsubdir/)'
+        )
 
     def test_copy_dir_does_not_upload_if_s3_dir_already_exists(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         bucket_name = 'test-12345'
         dir_path = 'testdir/testsubdir/'
         self.mock_internal_data_service.find_files.return_value = [
@@ -167,6 +197,7 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_copy_dir_uploads_single_file_in_new_dir(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         bucket_name = 'test-12345'
         dir_path = 'testdir/testsubdir/'
         self.mock_internal_data_service.find_files.return_value = [
@@ -183,13 +214,14 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_copy_dir_uploads_files_from_sub_dir_in_new_dir(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         bucket_name = 'test-12345'
         dir_path = 'testdir/testsubdir/'
         file_1 = FileInformation("/home/test/test1.txt", "test1.txt", "test1.txt")
         file_2 = FileInformation("/home/test/sub_1/test2.txt", "sub_1/test2.txt", "test2.txt")
         self.mock_internal_data_service.find_files.return_value = [file_1, file_2]
         self.mock_external_data_service.does_dir_exist.return_value = False
-        self.mock_external_data_service.upload_file.return_value = 44
+        self.mock_external_data_service.upload_file.side_effect = [42, 46]
         # Act
         response = self.test_service.copy_dir(bucket_name, dir_path)
         # Assert
@@ -197,15 +229,25 @@ class DataReplicationServiceTest(unittest.TestCase):
         assert response["new files transferred"] == 2
         assert response["data transferred (bytes)"] == 88
 
+    def test_try_delete_file_returns_warning_message_when_bucket_doesnt_exist(self):
+        # Arrange
+        bucket_name = "bucket-1"
+        self.mock_external_data_service.does_bucket_exist.return_value = False
+        # Act
+        response = self.test_service.try_delete_file(bucket_name, "some_file")
+        # Assert
+        assert response == return_delete_file_helper(
+            bucket_name='bucket-1',
+            file_name='some_file',
+            message='Warning, bucket bucket-1 does not exist in the S3 storage'
+        )
+
     def test_try_delete_file_returns_error_message_when_file_doesnt_exist(self):
         # Arrange
-        file_name = "unknown_file"
-        mock_bucket = mock.create_autospec(BucketInformation)
-        mock_bucket.name = "some-bucket"
-        self.mock_external_data_service.get_buckets.return_value = [mock_bucket]
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.does_object_exist.return_value = False
         # Act
-        response = self.test_service.try_delete_file(mock_bucket.name, file_name)
+        response = self.test_service.try_delete_file("some-bucket", "unknown_file")
         # Assert
         assert response == {'bucket': 'some-bucket',
                             'file': 'unknown_file',
@@ -213,27 +255,38 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_try_delete_file_returns_confirmation_message_when_file_does_exist(self):
         # Arrange
-        file_name = "known_file"
-        mock_bucket = mock.create_autospec(BucketInformation)
-        mock_bucket.name = "some-bucket"
-        self.mock_external_data_service.get_buckets.return_value = [mock_bucket]
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.does_object_exist.return_value = True
         # Act
-        response = self.test_service.try_delete_file(mock_bucket.name, file_name)
+        response = self.test_service.try_delete_file("some-bucket", "known_file")
         # Assert
         assert response == {'bucket': 'some-bucket',
                             'file': 'known_file',
                             'message': 'File known_file successfully deleted from bucket some-bucket'}
 
+    def test_copy_new_return_warning_when_bucket_not_found(self):
+        # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = False
+        # Act
+        response = self.test_service.copy_new("bucket", None)
+        # Assert
+        assert self.mock_external_data_service.upload_file.call_count == 0
+        assert response == {'message': 'Warning, bucket bucket does not exist in the S3 storage',
+                            'new files transferred': 0,
+                            'files updated': 0,
+                            'files skipped': 0,
+                            'data transferred (bytes)': 0}
+
     def test_copy_new_return_message_when_no_new_files_to_transfer(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1]
         self.mock_internal_data_service.find_files.return_value = [self.mock_file_information_1]
         self.mock_storage_difference_processor.return_new_files.return_value = []
         # Act
         response = self.test_service.copy_new("bucket", None)
-        assert self.mock_external_data_service.upload_file.call_count == 0
         # Assert
+        assert self.mock_external_data_service.upload_file.call_count == 0
         assert response == {'message': 'No new files found in directory or directory does not exist (root)',
                             'new files transferred': 0,
                             'files updated': 0,
@@ -242,6 +295,7 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_copy_new_return_message_directory_does_not_exist(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1]
         self.mock_internal_data_service.find_files.return_value = []
         self.mock_storage_difference_processor.return_new_files.return_value = []
@@ -257,6 +311,7 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_copy_new_return_message_when_new_files_transferred(self):
         # Arrange
+        self.mock_external_data_service.does_bucket_exist.return_value = True
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1]
         self.mock_internal_data_service.find_files.return_value = [self.mock_file_information_1,
                                                                    self.mock_file_information_2,

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -229,7 +229,7 @@ class DataReplicationServiceTest(unittest.TestCase):
         # Arrange
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1]
         self.mock_internal_data_service.find_files.return_value = [self.mock_file_information_1]
-        self.mock_storage_difference_processor.new_files.return_value = []
+        self.mock_storage_difference_processor.return_new_files.return_value = []
         # Act
         response = self.test_service.copy_new("bucket", None)
         assert self.mock_external_data_service.upload_file.call_count == 0
@@ -244,7 +244,7 @@ class DataReplicationServiceTest(unittest.TestCase):
         # Arrange
         self.mock_external_data_service.get_objects.return_value = [self.mock_object_1]
         self.mock_internal_data_service.find_files.return_value = []
-        self.mock_storage_difference_processor.new_files.return_value = []
+        self.mock_storage_difference_processor.return_new_files.return_value = []
         # Act
         response = self.test_service.copy_new("bucket", None)
         # Assert
@@ -262,8 +262,8 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                                    self.mock_file_information_2,
                                                                    self.mock_file_information_3]
         self.mock_external_data_service.upload_file.side_effect = [12, 34]
-        self.mock_storage_difference_processor.new_files.return_value = [self.mock_file_information_2,
-                                                                         self.mock_file_information_3]
+        self.mock_storage_difference_processor.return_new_files.return_value = [self.mock_file_information_2,
+                                                                                self.mock_file_information_3]
         # Act
         response = self.test_service.copy_new("bucket", "some_dir")
         # Assert

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -273,5 +273,3 @@ class DataReplicationServiceTest(unittest.TestCase):
                             'Files updated': 0,
                             'Files skipped': 1,
                             'Data transferred (bytes)': 46}
-
-

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -23,6 +23,7 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_logger = mock.create_autospec(logging.Logger)
         self.test_service = DataReplicationService(self.mock_external_data_service,
                                                    self.mock_internal_data_service,
+                                                   self.mock_storage_difference_processor,
                                                    self.mock_logger)
         # Mock_objects
         self.mock_object_1 = mock.create_autospec(S3ObjectInformation)
@@ -32,14 +33,12 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 2132142421.123123}
-        self.mock_object_1.object_name = "test"
         self.mock_object_2 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_2.to_dict.return_value = {"object_name": "test_2",
                                                    "bucket_name": "test_bucket",
                                                    "is_dir": False, "size": 100,
                                                    "etag": "test_etag_2",
                                                    "last_modified": 2132142421.123123}
-        self.mock_object_2.object_name = "test_2"
         self.mock_object_3 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_3.to_dict.return_value = {"object_name": "test_dir/test",
                                                    "bucket_name": "test_bucket",
@@ -47,7 +46,6 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 2132142421.123123}
-        self.mock_object_3.object_name = "test_dir/test"
         # mock file information
         self.mock_file_information_1 = mock.create_autospec(FileInformation)
         self.mock_file_information_1.rel_path = "test"
@@ -263,6 +261,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_internal_data_service.find_files.return_value = [self.mock_file_information_1,
                                                                    self.mock_file_information_2,
                                                                    self.mock_file_information_3]
+        self.mock_storage_difference_processor.return_new_files.return_value = [self.mock_file_information_2,
+                                                                                self.mock_file_information_3]
         self.mock_external_data_service.upload_file.side_effect = [12, 34]
         # Act
         response = self.test_service.copy_new("bucket", "some_dir")

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -105,8 +105,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.create_bucket(bucket_name)
         # Assert
         self.mock_external_data_service.create_bucket.assert_not_called()
-        self.assertEqual(response, {"Message": "Bucket breaks local naming standard (test-1234-)",
-                                    "Bucket": "test-1234-"})
+        self.assertEqual(response, {"message": "Bucket breaks local naming standard (test-1234-)",
+                                    "bucket": "test-1234-"})
 
     def test_create_bucket_return_correct_when_bucket_not_given(self):
         # Arrange
@@ -115,8 +115,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.create_bucket(bucket_name)
         # Assert
         self.mock_external_data_service.create_bucket.assert_not_called()
-        self.assertEqual(response, {"Message": "No bucket name provided",
-                                    "Bucket": ""})
+        self.assertEqual(response, {"message": "No bucket name provided",
+                                    "bucket": ""})
 
     def test_create_bucket_return_correct_when_bucket_already_exists(self):
         # Arrange
@@ -127,8 +127,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.create_bucket(bucket_name)
         # Assert
         self.mock_external_data_service.create_bucket.assert_not_called()
-        self.assertEqual(response, {"Message": "Bucket already exists (test-12345)",
-                                    "Bucket": "test-12345"})
+        self.assertEqual(response, {"message": "Bucket already exists (test-12345)",
+                                    "bucket": "test-12345"})
 
     def test_create_bucket_returns_correctly_when_successful(self):
         # Arrange
@@ -139,8 +139,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.create_bucket(bucket_name)
         # Assert
         self.mock_external_data_service.create_bucket.assert_called_once_with(bucket_name)
-        self.assertEqual(response, {"Message": "Bucket Created (test-12345)",
-                                    "Bucket": "test-12345"})
+        self.assertEqual(response, {"message": "Bucket Created (test-12345)",
+                                    "bucket": "test-12345"})
 
     def test_copy_dir_does_not_upload_if_no_local_files_found(self):
         # Arrange
@@ -178,8 +178,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.copy_dir(bucket_name, dir_path)
         # Assert
         self.mock_external_data_service.upload_file.assert_called_once()
-        assert response["Files transferred"] == 1
-        assert response["Data transferred (bytes)"] == 42
+        assert response["new files transferred"] == 1
+        assert response["data transferred (bytes)"] == 42
 
     def test_copy_dir_uploads_files_from_sub_dir_in_new_dir(self):
         # Arrange
@@ -194,8 +194,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.copy_dir(bucket_name, dir_path)
         # Assert
         assert self.mock_external_data_service.upload_file.call_count == 2
-        assert response["Files transferred"] == 2
-        assert response["Data transferred (bytes)"] == 88
+        assert response["new files transferred"] == 2
+        assert response["data transferred (bytes)"] == 88
 
     def test_try_delete_file_returns_error_message_when_file_doesnt_exist(self):
         # Arrange
@@ -207,9 +207,9 @@ class DataReplicationServiceTest(unittest.TestCase):
         # Act
         response = self.test_service.try_delete_file(mock_bucket.name, file_name)
         # Assert
-        assert response == {'Bucket': 'some-bucket',
-                            'File': 'unknown_file',
-                            'Message': 'File unknown_file does not exist in bucket some-bucket'}
+        assert response == {'bucket': 'some-bucket',
+                            'file': 'unknown_file',
+                            'message': 'File unknown_file does not exist in bucket some-bucket'}
 
     def test_try_delete_file_returns_confirmation_message_when_file_does_exist(self):
         # Arrange
@@ -221,9 +221,9 @@ class DataReplicationServiceTest(unittest.TestCase):
         # Act
         response = self.test_service.try_delete_file(mock_bucket.name, file_name)
         # Assert
-        assert response == {'Bucket': 'some-bucket',
-                            'File': 'known_file',
-                            'Message': 'File known_file successfully deleted from bucket some-bucket'}
+        assert response == {'bucket': 'some-bucket',
+                            'file': 'known_file',
+                            'message': 'File known_file successfully deleted from bucket some-bucket'}
 
     def test_copy_new_return_message_when_no_new_files_to_transfer(self):
         # Arrange
@@ -234,11 +234,11 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.copy_new("bucket", None)
         assert self.mock_external_data_service.upload_file.call_count == 0
         # Assert
-        assert response == {'Message': 'No new files found in directory or directory does not exist (root)',
-                            'Files transferred': 0,
-                            'Files updated': 0,
-                            'Files skipped': 1,
-                            'Data transferred (bytes)': 0}
+        assert response == {'message': 'No new files found in directory or directory does not exist (root)',
+                            'new files transferred': 0,
+                            'files updated': 0,
+                            'files skipped': 1,
+                            'data transferred (bytes)': 0}
 
     def test_copy_new_return_message_directory_does_not_exist(self):
         # Arrange
@@ -249,11 +249,11 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.copy_new("bucket", None)
         # Assert
         assert self.mock_external_data_service.upload_file.call_count == 0
-        assert response == {'Message': 'No new files found in directory or directory does not exist (root)',
-                            'Files transferred': 0,
-                            'Files updated': 0,
-                            'Files skipped': 0,
-                            'Data transferred (bytes)': 0}
+        assert response == {'message': 'No new files found in directory or directory does not exist (root)',
+                            'new files transferred': 0,
+                            'files updated': 0,
+                            'files skipped': 0,
+                            'data transferred (bytes)': 0}
 
     def test_copy_new_return_message_when_new_files_transferred(self):
         # Arrange
@@ -268,8 +268,8 @@ class DataReplicationServiceTest(unittest.TestCase):
         response = self.test_service.copy_new("bucket", "some_dir")
         # Assert
         assert self.mock_external_data_service.upload_file.call_count == 2
-        assert response == {'Message': 'Transfer successful, copied 2 new files from some_dir totalling 46 bytes',
-                            'Files transferred': 2,
-                            'Files updated': 0,
-                            'Files skipped': 1,
-                            'Data transferred (bytes)': 46}
+        assert response == {'message': 'Transfer successful, copied 2 new files from some_dir totalling 46 bytes',
+                            'new files transferred': 2,
+                            'files updated': 0,
+                            'files skipped': 1,
+                            'data transferred (bytes)': 46}

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -23,7 +23,6 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_logger = mock.create_autospec(logging.Logger)
         self.test_service = DataReplicationService(self.mock_external_data_service,
                                                    self.mock_internal_data_service,
-                                                   self.mock_storage_difference_processor,
                                                    self.mock_logger)
         # Mock_objects
         self.mock_object_1 = mock.create_autospec(S3ObjectInformation)
@@ -33,12 +32,14 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 2132142421.123123}
+        self.mock_object_1.object_name = "test"
         self.mock_object_2 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_2.to_dict.return_value = {"object_name": "test_2",
                                                    "bucket_name": "test_bucket",
                                                    "is_dir": False, "size": 100,
                                                    "etag": "test_etag_2",
                                                    "last_modified": 2132142421.123123}
+        self.mock_object_2.object_name = "test_2"
         self.mock_object_3 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_3.to_dict.return_value = {"object_name": "test_dir/test",
                                                    "bucket_name": "test_bucket",
@@ -46,6 +47,7 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 2132142421.123123}
+        self.mock_object_3.object_name = "test_dir/test"
         # mock file information
         self.mock_file_information_1 = mock.create_autospec(FileInformation)
         self.mock_file_information_1.rel_path = "test"
@@ -262,8 +264,6 @@ class DataReplicationServiceTest(unittest.TestCase):
                                                                    self.mock_file_information_2,
                                                                    self.mock_file_information_3]
         self.mock_external_data_service.upload_file.side_effect = [12, 34]
-        self.mock_storage_difference_processor.return_new_files.return_value = [self.mock_file_information_2,
-                                                                                self.mock_file_information_3]
         # Act
         response = self.test_service.copy_new("bucket", "some_dir")
         # Assert

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -5,13 +5,12 @@ import unittest
 import mock
 import pytest
 
+from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
 from DittoWebApi.src.models.file_information import FileInformation
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
-from DittoWebApi.src.services.internal_data_service import InternalDataService
-from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
-from DittoWebApi.src.models.bucket_information import BucketInformation
 from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
+from DittoWebApi.src.services.internal_data_service import InternalDataService
 from DittoWebApi.src.utils.return_helper import return_dict
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
 

--- a/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
@@ -16,18 +16,18 @@ class TestSorageDifferenceProcessor:
         self.file_3 = mock.create_autospec(FileInformation)
         self.file_4 = mock.create_autospec(FileInformation)
         self.file_1.rel_path = "file_1.txt"
-        self.file_2.rel_path = "file_2.txt"
-        self.file_3.rel_path = "file_3.txt"
-        self.file_4.rel_path = "file_4.txt"
+        self.file_2.rel_path = "some_dir/file_2.txt"
+        self.file_3.rel_path = r"some_win_dir\some_win_sub_dir\file_3.txt"
+        self.file_4.rel_path = r"some/badly\formed/path\file_4.txt"
         # Mock s3 objects
         self.s3_object_1 = mock.create_autospec(S3ObjectInformation)
         self.s3_object_2 = mock.create_autospec(S3ObjectInformation)
         self.s3_object_3 = mock.create_autospec(S3ObjectInformation)
         self.s3_object_4 = mock.create_autospec(S3ObjectInformation)
         self.s3_object_1.object_name = "file_1.txt"
-        self.s3_object_2.object_name = "file_2.txt"
-        self.s3_object_3.object_name = "file_3.txt"
-        self.s3_object_4.object_name = "file_4.txt"
+        self.s3_object_2.object_name = "some_dir/file_2.txt"
+        self.s3_object_3.object_name = "some_win_dir/some_win_sub_dir/file_3.txt"
+        self.s3_object_4.object_name = "some/badly/formed/path/file_4.txt"
 
     def test_new_files_returns_all_files_when_only_new_files_are_present(self):
         # Arrange
@@ -37,8 +37,8 @@ class TestSorageDifferenceProcessor:
         result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
-        assert result[0].rel_path == "file_1.txt"
-        assert result[1].rel_path == "file_2.txt"
+        assert result[0] == self.file_1
+        assert result[1] == self.file_2
 
     def test_new_files_returns_empty_array_when_all_files_are_already_present(self):
         # Arrange
@@ -49,7 +49,7 @@ class TestSorageDifferenceProcessor:
         # Assert
         assert result == []
 
-    def test_new_files_returns_only_new_files_when_some_are_new_and_some_are_already_present(self):
+    def test_new_files_returns_only_new_files_when_some_are_new_some_are_present_including_non_unix_paths(self):
         # Arrange
         objects_in_bucket = [self.s3_object_2]
         files_in_directory = [self.file_1, self.file_2, self.file_3]
@@ -57,8 +57,8 @@ class TestSorageDifferenceProcessor:
         result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
-        assert result[0].rel_path == "file_1.txt"
-        assert result[1].rel_path == "file_3.txt"
+        assert result[0] == self.file_1
+        assert result[1] == self.file_3
 
     def test_new_files_returns_only_new_files_when_there_is_extra_file_in_bucket_but_not_in_dir(self):
         # Arrange
@@ -68,8 +68,8 @@ class TestSorageDifferenceProcessor:
         result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
-        assert result[0].rel_path == "file_1.txt"
-        assert result[1].rel_path == "file_3.txt"
+        assert result[0] == self.file_1
+        assert result[1] == self.file_3
 
     def test_are_the_same_returns_true_when_objects_represent_the_same_file(self):
         # Arrange
@@ -82,9 +82,28 @@ class TestSorageDifferenceProcessor:
 
     def test_are_the_same_returns_false_when_objects_represent_different_files(self):
         # Arrange
-        s3_object = self.s3_object_3
+        s3_object = self.s3_object_2
         file_information = self.file_1
         # Act
         result = self.processor.are_the_same(s3_object, file_information)
         # Assert
         assert result is False
+
+    def test_are_the_same_returns_true_when_objects_represent_the_same_file_but_with_windows_path(self):
+        # Arrange
+        s3_object = self.s3_object_3
+        file_information = self.file_3
+        # Act
+        result = self.processor.are_the_same(s3_object, file_information)
+        # Assert
+        assert result is True
+
+    def test_are_the_same_returns_true_when_objects_represent_the_same_file_but_with_mixed_path(self):
+        # Arrange
+        s3_object = self.s3_object_4
+        file_information = self.file_4
+        # Act
+        result = self.processor.are_the_same(s3_object, file_information)
+        # Assert
+        assert result is True
+

--- a/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
@@ -1,0 +1,90 @@
+import pytest
+import mock
+from DittoWebApi.src.models.file_information import FileInformation
+from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
+from DittoWebApi.src.services.data_replication.storage_difference_processor import StorageDifferenceProcessor
+
+
+class TestSorageDifferenceProcessor:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.processor = StorageDifferenceProcessor()
+        # Mock file information objects
+        self.file_1 = mock.create_autospec(FileInformation)
+        self.file_2 = mock.create_autospec(FileInformation)
+        self.file_3 = mock.create_autospec(FileInformation)
+        self.file_4 = mock.create_autospec(FileInformation)
+        self.file_1.rel_path = "file_1.txt"
+        self.file_2.rel_path = "file_2.txt"
+        self.file_3.rel_path = "file_3.txt"
+        self.file_4.rel_path = "file_4.txt"
+        # Mock s3 objects
+        self.s3_object_1 = mock.create_autospec(S3ObjectInformation)
+        self.s3_object_2 = mock.create_autospec(S3ObjectInformation)
+        self.s3_object_3 = mock.create_autospec(S3ObjectInformation)
+        self.s3_object_4 = mock.create_autospec(S3ObjectInformation)
+        self.s3_object_1.object_name = "file_1.txt"
+        self.s3_object_2.object_name = "file_2.txt"
+        self.s3_object_3.object_name = "file_3.txt"
+        self.s3_object_4.object_name = "file_4.txt"
+
+    def test_new_files_returns_all_files_when_only_new_files_are_present(self):
+        # Arrange
+        objects_in_bucket = []
+        files_in_directory = [self.file_1, self.file_2]
+        # Act
+        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        # Assert
+        assert len(result) == 2
+        assert result[0].rel_path == "file_1.txt"
+        assert result[1].rel_path == "file_2.txt"
+
+    def test_new_files_returns_empty_array_when_all_files_are_already_present(self):
+        # Arrange
+        objects_in_bucket = [self.s3_object_1, self.s3_object_2]
+        files_in_directory = [self.file_1, self.file_2]
+        # Act
+        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        # Assert
+        assert result == []
+
+    def test_new_files_returns_only_new_files_when_some_are_new_and_some_are_already_present(self):
+        # Arrange
+        objects_in_bucket = [self.s3_object_2]
+        files_in_directory = [self.file_1, self.file_2, self.file_3]
+        # Act
+        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        # Assert
+        assert len(result) == 2
+        assert result[0].rel_path == "file_1.txt"
+        assert result[1].rel_path == "file_3.txt"
+
+    def test_new_files_returns_only_new_files_when_there_is_extra_file_in_bucket_but_not_in_dir(self):
+        # Arrange
+        objects_in_bucket = [self.s3_object_2, self.s3_object_4]
+        files_in_directory = [self.file_1, self.file_2, self.file_3]
+        # Act
+        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        # Assert
+        assert len(result) == 2
+        assert result[0].rel_path == "file_1.txt"
+        assert result[1].rel_path == "file_3.txt"
+
+    def test_are_the_same_returns_true_when_objects_represent_the_same_file(self):
+        # Arrange
+        s3_object = self.s3_object_2
+        file_information = self.file_2
+        # Act
+        result = self.processor.are_the_same(s3_object, file_information)
+        # Assert
+        assert result is True
+
+    def test_are_the_same_returns_false_when_objects_represent_different_files(self):
+        # Arrange
+        s3_object = self.s3_object_3
+        file_information = self.file_1
+        # Act
+        result = self.processor.are_the_same(s3_object, file_information)
+        # Assert
+        assert result is False
+

--- a/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
@@ -106,4 +106,3 @@ class TestSorageDifferenceProcessor:
         result = self.processor.are_the_same(s3_object, file_information)
         # Assert
         assert result is True
-

--- a/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
@@ -34,7 +34,7 @@ class TestSorageDifferenceProcessor:
         objects_in_bucket = []
         files_in_directory = [self.file_1, self.file_2]
         # Act
-        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
         assert result[0].rel_path == "file_1.txt"
@@ -45,7 +45,7 @@ class TestSorageDifferenceProcessor:
         objects_in_bucket = [self.s3_object_1, self.s3_object_2]
         files_in_directory = [self.file_1, self.file_2]
         # Act
-        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert result == []
 
@@ -54,7 +54,7 @@ class TestSorageDifferenceProcessor:
         objects_in_bucket = [self.s3_object_2]
         files_in_directory = [self.file_1, self.file_2, self.file_3]
         # Act
-        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
         assert result[0].rel_path == "file_1.txt"
@@ -65,7 +65,7 @@ class TestSorageDifferenceProcessor:
         objects_in_bucket = [self.s3_object_2, self.s3_object_4]
         files_in_directory = [self.file_1, self.file_2, self.file_3]
         # Act
-        result = self.processor.new_files(objects_in_bucket, files_in_directory)
+        result = self.processor.return_new_files(objects_in_bucket, files_in_directory)
         # Assert
         assert len(result) == 2
         assert result[0].rel_path == "file_1.txt"

--- a/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/storage_difference_processor_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=W0201,
 import pytest
 import mock
 from DittoWebApi.src.models.file_information import FileInformation
@@ -87,4 +88,3 @@ class TestSorageDifferenceProcessor:
         result = self.processor.are_the_same(s3_object, file_information)
         # Assert
         assert result is False
-

--- a/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
@@ -3,17 +3,25 @@ from DittoWebApi.src.utils.file_system.path_helpers import to_posix
 
 
 class TestPathHelpers(unittest.TestCase):
-    def test_windows_path_converted_to_unix(self):
+    def test_windows_path_converted_to_posix(self):
         path = r'c\test\subdir\file.txt'
         self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
 
-    def test_mixed_paths_converted_to_linux_paths(self):
+    def test_mixed_path_converted_to_posix(self):
+        path = r"c/test\subdir/file.txt"
+        self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
+
+    def test_posix_path_remain_posix(self):
         path = r"c/test/subdir/file.txt"
         self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
 
-    def test_linux_paths_remain_linux_paths(self):
-        path = r"c/test/subdir/file.txt"
-        self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
+    def test_windows_directory_converts_to_posix_final_slash_removed(self):
+        path = r"C:\\test\\subdir\\"
+        self.assertEqual(to_posix(path), r"C:/test/subdir")
+
+    def test_posix_directory_remain_posix_final_slash_removed(self):
+        path = r"C:/test/subdir/"
+        self.assertEqual(to_posix(path), r"C:/test/subdir")
 
     def test_blank_string_remains_empty(self):
         path = r" "

--- a/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
@@ -1,16 +1,18 @@
 import unittest
-from pathlib import PureWindowsPath
-from pathlib import PurePosixPath
 from DittoWebApi.src.utils.file_system.path_helpers import to_posix
 
 
 class TestPathHelpers(unittest.TestCase):
     def test_windows_path_converted_to_unix(self):
-        path = PureWindowsPath(r'c\test\subdir\file.txt')
+        path = r'c\test\subdir\file.txt'
+        self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
+
+    def test_mixed_paths_converted_to_linux_paths(self):
+        path = r"c/test/subdir/file.txt"
         self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
 
     def test_linux_paths_remain_linux_paths(self):
-        path = PurePosixPath(r"c/test/subdir/file.txt")
+        path = r"c/test/subdir/file.txt"
         self.assertEqual(to_posix(path), r"c/test/subdir/file.txt")
 
     def test_blank_string_remains_empty(self):

--- a/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
@@ -1,36 +1,36 @@
 import unittest
-from DittoWebApi.src.utils.return_helper import return_dict
+from DittoWebApi.src.utils.return_helper import return_transfer_summary
 
 
 class TestReturnHelper(unittest.TestCase):
     def test_correct_return_when_message_is_added_for_return_dict(self):
         message = "Some text"
-        test_dict = return_dict(files_transferred=5,
-                                files_skipped=2,
-                                files_updated=4,
-                                data_transferred=102,
-                                message=message)
+        test_dict = return_transfer_summary(files_transferred=5,
+                                            files_skipped=2,
+                                            files_updated=4,
+                                            data_transferred=102,
+                                            message=message)
         self.assertEqual(test_dict, {"message": message,
-                                     "new files transferred": 5,
+                                     "new files uploaded": 5,
                                      "files updated": 4,
                                      "files skipped": 2,
                                      "data transferred (bytes)": 102})
 
     def test_correct_return_when__no_message_is_added_for_return_dict(self):
-        test_dict = return_dict(files_transferred=6,
-                                files_skipped=3,
-                                files_updated=1,
-                                data_transferred=2532,)
+        test_dict = return_transfer_summary(files_transferred=6,
+                                            files_skipped=3,
+                                            files_updated=1,
+                                            data_transferred=2532, )
         self.assertEqual(test_dict, {"message": "",
-                                     "new files transferred": 6,
+                                     "new files uploaded": 6,
                                      "files updated": 1,
                                      "files skipped": 3,
                                      "data transferred (bytes)": 2532})
 
     def test_default_dict_returned_when_return_dict_called_with_no_args(self):
-        test_dict = return_dict()
+        test_dict = return_transfer_summary()
         self.assertEqual(test_dict, {"message": "",
-                                     "new files transferred": 0,
+                                     "new files uploaded": 0,
                                      "files updated": 0,
                                      "files skipped": 0,
                                      "data transferred (bytes)": 0})

--- a/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
@@ -10,27 +10,27 @@ class TestReturnHelper(unittest.TestCase):
                                 files_updated=4,
                                 data_transferred=102,
                                 message=message)
-        self.assertEqual(test_dict, {"Message": message,
-                                     "Files transferred": 5,
-                                     "Files updated": 4,
-                                     "Files skipped": 2,
-                                     "Data transferred (bytes)": 102})
+        self.assertEqual(test_dict, {"message": message,
+                                     "new files transferred": 5,
+                                     "files updated": 4,
+                                     "files skipped": 2,
+                                     "data transferred (bytes)": 102})
 
     def test_correct_return_when__no_message_is_added_for_return_dict(self):
         test_dict = return_dict(files_transferred=6,
                                 files_skipped=3,
                                 files_updated=1,
                                 data_transferred=2532,)
-        self.assertEqual(test_dict, {"Message": "",
-                                     "Files transferred": 6,
-                                     "Files updated": 1,
-                                     "Files skipped": 3,
-                                     "Data transferred (bytes)": 2532})
+        self.assertEqual(test_dict, {"message": "",
+                                     "new files transferred": 6,
+                                     "files updated": 1,
+                                     "files skipped": 3,
+                                     "data transferred (bytes)": 2532})
 
     def test_default_dict_returned_when_return_dict_called_with_no_args(self):
         test_dict = return_dict()
-        self.assertEqual(test_dict, {"Message": "",
-                                     "Files transferred": 0,
-                                     "Files updated": 0,
-                                     "Files skipped": 0,
-                                     "Data transferred (bytes)": 0})
+        self.assertEqual(test_dict, {"message": "",
+                                     "new files transferred": 0,
+                                     "files updated": 0,
+                                     "files skipped": 0,
+                                     "data transferred (bytes)": 0})


### PR DESCRIPTION
Develop new handler copynew to compare files in directory with those already in the s3 bucket and transfer across only the new files.

To test:
* Run the unit tests
* Load up the virtual environment make some new files and use copydir to copy the files across. Then use deletefile to delete a few of the files and then use copynew to transfer back the files you removed. 
 