### PR TITLE
Feature/setup security #27

### DIFF
--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -13,6 +13,7 @@ from DittoWebApi.src.services.data_replication.storage_difference_processor impo
 from DittoWebApi.src.services.external.external_data_service import ExternalDataService
 from DittoWebApi.src.services.external.storage_adapters.boto_adapter import BotoAdapter
 from DittoWebApi.src.services.internal_data_service import InternalDataService
+from DittoWebApi.src.services.security.config_security_service import ConfigSecurityService
 from DittoWebApi.src.utils.configurations import Configuration
 from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHelper
 from DittoWebApi.src.utils.route_helper import format_route_specification
@@ -58,8 +59,15 @@ if __name__ == "__main__":
                                                       STORAGE_DIFFERENCE_PROCESSOR,
                                                       LOGGER)
 
+    # Security (PLACEHOLDER CODE)
+    SECURITY_CONFIGURATION_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'security_configuration.ini'))
+    SECURITY_SERVICE = ConfigSecurityService(SECURITY_CONFIGURATION_PATH, LOGGER)
+
     # Launch app
-    app_context = dict(data_replication_service=DATA_REPLICATION_SERVICE)
+    app_context = dict(
+        data_replication_service=DATA_REPLICATION_SERVICE,
+        security_service=SECURITY_SERVICE
+    )
     APP = tornado.web.Application([
         (format_route_specification("listpresent"), ListPresentHandler, app_context),
         (format_route_specification("copydir"), CopyDirHandler, app_context),

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -2,6 +2,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 import os
 import tornado
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.list_present import ListPresentHandler
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
@@ -69,6 +70,7 @@ if __name__ == "__main__":
         security_service=SECURITY_SERVICE
     )
     APP = tornado.web.Application([
+        (format_route_specification("help"), DittoHandler, app_context),
         (format_route_specification("listpresent"), ListPresentHandler, app_context),
         (format_route_specification("copydir"), CopyDirHandler, app_context),
         (format_route_specification("createbucket"), CreateBucketHandler, app_context),

--- a/ditto_web_api/DittoWebApi/main.py
+++ b/ditto_web_api/DittoWebApi/main.py
@@ -65,18 +65,18 @@ if __name__ == "__main__":
     SECURITY_SERVICE = ConfigSecurityService(SECURITY_CONFIGURATION_PATH, LOGGER)
 
     # Launch app
-    app_context = dict(
+    CONTAINER = dict(
         data_replication_service=DATA_REPLICATION_SERVICE,
         security_service=SECURITY_SERVICE
     )
     APP = tornado.web.Application([
-        (format_route_specification("help"), DittoHandler, app_context),
-        (format_route_specification("listpresent"), ListPresentHandler, app_context),
-        (format_route_specification("copydir"), CopyDirHandler, app_context),
-        (format_route_specification("createbucket"), CreateBucketHandler, app_context),
-        (format_route_specification("deletefile"), DeleteFileHandler, app_context),
-        (format_route_specification("copynew"), CopyNewHandler, app_context),
-        (format_route_specification("copyupdate"), CopyUpdateHandler, app_context),
+        (format_route_specification("help"), DittoHandler, CONTAINER),
+        (format_route_specification("listpresent"), ListPresentHandler, CONTAINER),
+        (format_route_specification("copydir"), CopyDirHandler, CONTAINER),
+        (format_route_specification("createbucket"), CreateBucketHandler, CONTAINER),
+        (format_route_specification("deletefile"), DeleteFileHandler, CONTAINER),
+        (format_route_specification("copynew"), CopyNewHandler, CONTAINER),
+        (format_route_specification("copyupdate"), CopyUpdateHandler, CONTAINER),
     ])
     LOGGER.info(f'DITTO Web API listening on port {CONFIGURATION.app_port}')
     APP.listen(CONFIGURATION.app_port)

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -6,8 +6,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_outp
 
 
 class CopyDirHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -1,15 +1,11 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
 
 
-class CopyDirHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class CopyDirHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -22,8 +22,7 @@ class CopyDirHandler(DittoHandler):
         },
     )
     def post(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
-        dir_path = attrs["directory"] if "directory" in attrs.keys() else None
+        bucket_name = self.get_body_attribute("bucket", required=True)
+        dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -6,8 +6,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_outp
 
 
 class CopyNewHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -22,8 +22,7 @@ class CopyNewHandler(DittoHandler):
         },
     )
     def post(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
-        dir_path = attrs["directory"] if "directory" in attrs.keys() else None
+        bucket_name = self.get_body_attribute("bucket", required=True)
+        dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new(bucket_name, dir_path)
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -1,15 +1,11 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
 
 
-class CopyNewHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class CopyNewHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -23,8 +23,7 @@ class CopyUpdateHandler(DittoHandler):
         },
     )
     def post(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
-        dir_path = attrs["directory"] if "directory" in attrs.keys() else None
+        bucket_name = self.get_body_attribute("bucket", required=True)
+        dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new_and_update(bucket_name, dir_path)
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -6,8 +6,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_outp
 
 
 class CopyUpdateHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -1,15 +1,11 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
 
 
-class CopyUpdateHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class CopyUpdateHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -21,7 +21,6 @@ class CreateBucketHandler(DittoHandler):
         }
     )
     def post(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
+        bucket_name = self.get_body_attribute("bucket", required=True)
         result = self._data_replication_service.create_bucket(bucket_name)
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -5,8 +5,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema
 
 
 class CreateBucketHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket"], ["bucket"]),

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -1,14 +1,10 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 
 
-class CreateBucketHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class CreateBucketHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket"], ["bucket"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -20,8 +20,7 @@ class DeleteFileHandler(DittoHandler):
 
     )
     def delete(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
-        file_name = attrs["file"]
-        result = self._data_replication_service.try_delete_file(bucket_name, file_name)
+        bucket_name = self.get_body_attribute("bucket", required=True)
+        file_rel_path = self.get_body_attribute("file", required=True)
+        result = self._data_replication_service.try_delete_file(bucket_name, file_rel_path)
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -1,14 +1,10 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 
 
-class DeleteFileHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class DeleteFileHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "file"], ["bucket", "file"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -5,8 +5,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema
 
 
 class DeleteFileHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "file"], ["bucket", "file"]),

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -1,0 +1,35 @@
+from base64 import b64decode
+
+from tornado_json.requesthandlers import APIHandler
+
+
+class DittoHandler(APIHandler):
+    def initialize(self, data_replication_service, security_service):
+        self._data_replication_service = data_replication_service
+        self._security_service = security_service
+
+    def prepare(self):
+        self._check_credentials()
+
+    def post(self, *args, **kwargs):
+        user = self._current_user
+        self.write(f'Hello {user}')
+
+    def _check_credentials(self):
+        auth_header = self.request.headers.get('Authorization')
+        if not auth_header or not auth_header.startswith('Basic '):
+            self._authentication_failed()
+            return
+
+        auth_data = auth_header.split(None, 1)[-1]
+        auth_data = b64decode(auth_data).decode('ascii')
+        username, password = auth_data.split(':', 1)
+
+        credentials_accepted = self._security_service.is_authenticated(username, password)
+        if credentials_accepted:
+            self._current_user = username
+        else:
+            self._authentication_failed()
+
+    def _authentication_failed(self):
+        super(APIHandler, self).write_error(401)

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -11,10 +11,6 @@ class DittoHandler(APIHandler):
     def prepare(self):
         self._check_credentials()
 
-    def post(self, *args, **kwargs):
-        user = self._current_user
-        self.write(f'Hello {user}')
-
     def _check_credentials(self):
         auth_header = self.request.headers.get('Authorization')
         if not auth_header or not auth_header.startswith('Basic '):

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -11,6 +11,14 @@ class DittoHandler(APIHandler):
     def prepare(self):
         self._check_credentials()
 
+    def get_body_attribute(self, key, default=None, required=False):
+        attrs = dict(self.body)
+        if key in attrs.keys():
+            return attrs[key]
+        if required:
+            raise ValueError('Attribute missing')
+        return default
+
     def _check_credentials(self):
         auth_header = self.request.headers.get('Authorization')
         if not auth_header or not auth_header.startswith('Basic '):

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -4,6 +4,7 @@ from tornado_json.requesthandlers import APIHandler
 
 
 class DittoHandler(APIHandler):
+    # pylint: disable=arguments-differ
     def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
         self._security_service = security_service
@@ -12,6 +13,7 @@ class DittoHandler(APIHandler):
         self._check_credentials()
 
     def get_body_attribute(self, key, default=None, required=False):
+        # pylint: disable=no-member
         attrs = dict(self.body)
         if key in attrs.keys():
             return attrs[key]
@@ -31,6 +33,7 @@ class DittoHandler(APIHandler):
 
         credentials_accepted = self._security_service.check_credentials(username, password)
         if credentials_accepted:
+            # pylint: disable=attribute-defined-outside-init
             self._current_user = username
         else:
             self._authentication_failed()

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -14,9 +14,8 @@ class DittoHandler(APIHandler):
 
     def get_body_attribute(self, key, default=None, required=False):
         # pylint: disable=no-member
-        attrs = dict(self.body)
-        if key in attrs.keys():
-            return attrs[key]
+        if key in self.body:
+            return self.body[key]
         if required:
             raise ValueError('Attribute missing')
         return default

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -25,7 +25,7 @@ class DittoHandler(APIHandler):
         auth_data = b64decode(auth_data).decode('ascii')
         username, password = auth_data.split(':', 1)
 
-        credentials_accepted = self._security_service.is_authenticated(username, password)
+        credentials_accepted = self._security_service.check_credentials(username, password)
         if credentials_accepted:
             self._current_user = username
         else:

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -32,4 +32,5 @@ class DittoHandler(APIHandler):
             self._authentication_failed()
 
     def _authentication_failed(self):
-        super(APIHandler, self).write_error(401)
+        self.set_status(401)
+        self.finish({'reason': 'Authentication required'})

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -20,8 +20,7 @@ class ListPresentHandler(DittoHandler):
         },
     )
     def post(self, *args, **kwargs):
-        attrs = dict(self.body)
-        bucket_name = attrs["bucket"]
-        dir_path = attrs["directory"] if "directory" in attrs.keys() else None
+        bucket_name = self.get_body_attribute("bucket", required=True)
+        dir_path = self.get_body_attribute("directory", default=None)
         object_dicts = self._data_replication_service.retrieve_object_dicts(bucket_name, dir_path)
         return object_dicts

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -1,15 +1,11 @@
 # pylint: disable=W0221,W0223
-from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_list_present_output_schema
 
 
-class ListPresentHandler(APIHandler):
-    def initialize(self, data_replication_service, security_service):
-        self._data_replication_service = data_replication_service
-        self._security_service = security_service
-
+class ListPresentHandler(DittoHandler):
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),
         input_example={

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -6,8 +6,9 @@ from DittoWebApi.src.handlers.schemas.schema_helpers import create_list_present_
 
 
 class ListPresentHandler(APIHandler):
-    def initialize(self, data_replication_service):
+    def initialize(self, data_replication_service, security_service):
         self._data_replication_service = data_replication_service
+        self._security_service = security_service
 
     @schema.validate(
         input_schema=create_object_schema_with_string_properties(["bucket", "directory"], ["bucket"]),

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -79,24 +79,24 @@ class DataReplicationService:
         self._external_data_service.create_bucket(bucket_name)
         return return_bucket_message(messages.bucket_created(bucket_name), bucket_name)
 
-    def try_delete_file(self, bucket_name, file_name):
+    def try_delete_file(self, bucket_name, file_rel_path):
         self._logger.debug("Called delete-file handler")
         bucket_warning = self._check_bucket_warning(bucket_name)
         if bucket_warning is not None:
             return return_delete_file_helper(message=bucket_warning,
-                                             file_name=file_name,
+                                             file_rel_path=file_rel_path,
                                              bucket_name=bucket_name)
 
-        if not self._external_data_service.does_object_exist(bucket_name, file_name):
-            warning = messages.file_existence_warning(file_name, bucket_name)
+        if not self._external_data_service.does_object_exist(bucket_name, file_rel_path):
+            warning = messages.file_existence_warning(file_rel_path, bucket_name)
             self._logger.warning(warning)
             return return_delete_file_helper(message=warning,
-                                             file_name=file_name,
+                                             file_rel_path=file_rel_path,
                                              bucket_name=bucket_name)
-        self._external_data_service.delete_file(bucket_name, file_name)
-        return return_delete_file_helper(message=messages.file_deleted(file_name, bucket_name),
-                                         file_name=file_name,
-                                         bucket_name=bucket_name)
+        self._external_data_service.delete_file(bucket_name, file_rel_path)
+        msg = messages.file_deleted(file_rel_path, bucket_name)
+        action_summary = return_delete_file_helper(message=msg, file_rel_path=file_rel_path, bucket_name=bucket_name)
+        return action_summary
 
     def copy_new(self, bucket_name, dir_path):
         self._logger.debug("Called copy new handler")

--- a/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
@@ -25,9 +25,7 @@ class ConfigSecurityService(ISecurityService):
     def _parse(self, configuration_path):
         config = configparser.ConfigParser()
         config.read(configuration_path)
-        if len(config.keys()) > len(set(config.keys())):
-            raise ValueError('All user names must be unique')
-        self._users = {name: User(config[name]) for name in config.keys()}
+        self._users = {ConfigSecurityService._format_name(name): User(config[name]) for name in config.sections()}
         self._logger.info(f'Security Service found {len(self._users)} in configuration file "{configuration_path}"')
 
     def is_authenticated(self, name, password):
@@ -49,7 +47,12 @@ class ConfigSecurityService(ISecurityService):
         return is_in_group
 
     def _get_user(self, name):
-        if name not in self._users.keys():
+        formatted_name = ConfigSecurityService._format_name(name)
+        if formatted_name not in self._users.keys():
             self._logger.info(f'User "{name}" does not exist')
             return None
-        return self._users[name]
+        return self._users[formatted_name]
+
+    @staticmethod
+    def _format_name(name):
+        return name.lower().strip()

--- a/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
@@ -26,7 +26,9 @@ class ConfigSecurityService(ISecurityService):
         config = configparser.ConfigParser()
         config.read(configuration_path)
         self._users = {ConfigSecurityService._format_name(name): User(config[name]) for name in config.sections()}
-        self._logger.info(f'Security Service found {len(self._users)} in configuration file "{configuration_path}"')
+        self._logger.info(
+            f'Security Service found {len(self._users)} users in configuration file "{configuration_path}"'
+        )
 
     def is_authenticated(self, name, password):
         self._logger.info(f'Trying to authenticate user "{name}"')
@@ -48,7 +50,7 @@ class ConfigSecurityService(ISecurityService):
 
     def _get_user(self, name):
         formatted_name = ConfigSecurityService._format_name(name)
-        if formatted_name not in self._users.keys():
+        if formatted_name not in self._users:
             self._logger.info(f'User "{name}" does not exist')
             return None
         return self._users[formatted_name]

--- a/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
@@ -30,7 +30,7 @@ class ConfigSecurityService(ISecurityService):
             f'Security Service found {len(self._users)} users in configuration file "{configuration_path}"'
         )
 
-    def is_authenticated(self, name, password):
+    def check_credentials(self, name, password):
         self._logger.info(f'Trying to authenticate user "{name}"')
         user = self._get_user(name)
         if user is None:

--- a/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/config_security_service.py
@@ -1,0 +1,55 @@
+import configparser
+
+from DittoWebApi.src.services.security.isecurity_service import ISecurityService
+from DittoWebApi.src.utils.parse_strings import str2list
+
+
+class User:
+    def __init__(self, properties):
+        self._groups = str2list(properties['groups'])
+        self._password = properties['password']
+
+    def is_password(self, password):
+        return password == self._password
+
+    def is_in_group(self, group):
+        return group in self._groups
+
+
+class ConfigSecurityService(ISecurityService):
+    def __init__(self, configuration_path, logger):
+        self._users = None
+        self._logger = logger
+        self._parse(configuration_path)
+
+    def _parse(self, configuration_path):
+        config = configparser.ConfigParser()
+        config.read(configuration_path)
+        if len(config.keys()) > len(set(config.keys())):
+            raise ValueError('All user names must be unique')
+        self._users = {name: User(config[name]) for name in config.keys()}
+        self._logger.info(f'Security Service found {len(self._users)} in configuration file "{configuration_path}"')
+
+    def is_authenticated(self, name, password):
+        self._logger.info(f'Trying to authenticate user "{name}"')
+        user = self._get_user(name)
+        if user is None:
+            return False
+        password_correct = user.is_password(password)
+        self._logger.info(f'User "{name}" {"authenticated successfully" if password_correct else "password invalid"}')
+        return password_correct
+
+    def is_in_group(self, name, group):
+        self._logger.info(f'Trying to check group "{group}" for user "{name}"')
+        user = self._get_user(name)
+        if user is None:
+            return False
+        is_in_group = user.is_in_group(group)
+        self._logger.info(f'User "{name}" {"is" if is_in_group else "is not"} in group "{group}"')
+        return is_in_group
+
+    def _get_user(self, name):
+        if name not in self._users.keys():
+            self._logger.info(f'User "{name}" does not exist')
+            return None
+        return self._users[name]

--- a/ditto_web_api/DittoWebApi/src/services/security/isecurity_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/isecurity_service.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 class ISecurityService(metaclass=ABCMeta):
 
     @abstractmethod
-    def is_authenticated(self, name, password):
+    def check_credentials(self, name, password):
         pass
 
     @abstractmethod

--- a/ditto_web_api/DittoWebApi/src/services/security/isecurity_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/security/isecurity_service.py
@@ -1,0 +1,12 @@
+from abc import ABCMeta, abstractmethod
+
+
+class ISecurityService(metaclass=ABCMeta):
+
+    @abstractmethod
+    def is_authenticated(self, name, password):
+        pass
+
+    @abstractmethod
+    def is_in_group(self, name, group):
+        pass

--- a/ditto_web_api/DittoWebApi/src/utils/parse_strings.py
+++ b/ditto_web_api/DittoWebApi/src/utils/parse_strings.py
@@ -13,6 +13,13 @@ def str2bool(string):
     raise ValueError("'{}' not recognised as a Boolean. Use 'True' or 'False' (case insensitive)." .format(string))
 
 
+def str2list(string, sep=',', strip=True):
+    listed = string.split(sep)
+    if strip:
+        listed = [item.strip() for item in listed]
+    return listed
+
+
 def str2non_negative_int(string):
     integer = int(string)
     if integer < 0:

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -11,7 +11,7 @@ def return_bucket_message(message, bucket_name=""):
             "bucket": bucket_name}
 
 
-def return_delete_file_helper(message, file_name, bucket_name):
+def return_delete_file_helper(message, file_rel_path, bucket_name):
     return {"message": message,
-            "file": file_name,
+            "file": file_rel_path,
             "bucket": bucket_name}

--- a/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
@@ -18,11 +18,11 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
         pass
 
     @property
-    def auth_username(self):
+    def _auth_username(self):
         return 'testuser'
 
     @property
-    def auth_password(self):
+    def _auth_password(self):
         return 'password'
 
     def get_app(self):
@@ -46,8 +46,8 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
     def send_authorised_DELETE_request(self, body):
         return self._send_request("DELETE",
                                   body,
-                                  self.auth_username,
-                                  self.auth_password,
+                                  self._auth_username,
+                                  self._auth_password,
                                   allow_nonstandard_methods=True)
 
     # pylint: disable=invalid-name
@@ -56,7 +56,7 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
 
     # pylint: disable=invalid-name
     def send_authorised_POST_request(self, body):
-        return self._send_request("POST", body, self.auth_username, self.auth_password)
+        return self._send_request("POST", body, self._auth_username, self._auth_password)
 
     def assert_post_returns_401_when_no_credentials_given(self):
         # Arrange
@@ -76,6 +76,7 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
         with pytest.raises(HTTPClientError) as error:
             yield self.send_authorised_POST_request(body)
         # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self._auth_username, self._auth_password)
         assert error.value.response.code == 401
 
     def assert_post_returns_200_when_credentials_accepted(self):
@@ -86,7 +87,7 @@ class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
         body = {'bucket': "test-bucket", }
         response_body, response_code = yield self.send_authorised_POST_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        self.mock_security_service.check_credentials.assert_called_once_with(self._auth_username, self._auth_password)
         assert response_code == 200
         assert response_body['status'] == 'success'
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
 import json
+import mock
 import pytest
 from tornado.httpclient import HTTPClientError
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import Application
-import unittest.mock as mock
 
 from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
 from DittoWebApi.src.services.security.isecurity_service import ISecurityService

--- a/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/base_handler_test.py
@@ -1,0 +1,103 @@
+from abc import ABCMeta, abstractmethod
+import json
+import pytest
+from tornado.httpclient import HTTPClientError
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+import unittest.mock as mock
+
+from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from DittoWebApi.src.services.security.isecurity_service import ISecurityService
+from DittoWebApi.src.utils.route_helper import format_route_specification
+
+
+class BaseHandlerTest(AsyncHTTPTestCase, metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def handler(self):
+        pass
+
+    @property
+    def auth_username(self):
+        return 'testuser'
+
+    @property
+    def auth_password(self):
+        return 'password'
+
+    def get_app(self):
+        self.mock_data_replication_service = mock.create_autospec(DataReplicationService)
+        self.mock_security_service = mock.create_autospec(ISecurityService)
+        self.container = {
+            'data_replication_service': self.mock_data_replication_service,
+            'security_service': self.mock_security_service
+        }
+        application = Application([
+            (format_route_specification("testroute"), self.handler, self.container),
+        ])
+        self.url = self.get_url(r"/testroute/")
+        return application
+
+    # pylint: disable=invalid-name
+    def send_DELETE_request(self, body):
+        return self._send_request("DELETE", body, None, None, allow_nonstandard_methods=True)
+
+    # pylint: disable=invalid-name
+    def send_authorised_DELETE_request(self, body):
+        return self._send_request("DELETE",
+                                  body,
+                                  self.auth_username,
+                                  self.auth_password,
+                                  allow_nonstandard_methods=True)
+
+    # pylint: disable=invalid-name
+    def send_POST_request(self, body):
+        return self._send_request("POST", body, None, None)
+
+    # pylint: disable=invalid-name
+    def send_authorised_POST_request(self, body):
+        return self._send_request("POST", body, self.auth_username, self.auth_password)
+
+    def assert_post_returns_401_when_no_credentials_given(self):
+        # Arrange
+        self.mock_security_service.check_credentials.return_value = False
+        # Act
+        body = {'bucket': "test-bucket", }
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_POST_request(body)
+        # Assert
+        assert error.value.response.code == 401
+
+    def assert_post_returns_401_when_invalid_credentials_given(self):
+        # Arrange
+        self.mock_security_service.check_credentials.return_value = False
+        # Act
+        body = {'bucket': "test-bucket", }
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_authorised_POST_request(body)
+        # Assert
+        assert error.value.response.code == 401
+
+    def assert_post_returns_200_when_credentials_accepted(self):
+        # Arrange
+        self.mock_data_replication_service.retrieve_object_dicts.return_value = {}
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+
+    async def _send_request(self, method, body, username, password, allow_nonstandard_methods=False):
+        response = await self.http_client.fetch(
+            self.url,
+            method=method,
+            body=json.dumps(body),
+            auth_username=username,
+            auth_password=password,
+            allow_nonstandard_methods=allow_nonstandard_methods
+        )
+        response_body = json.loads(response.body, encoding='utf-8')
+        return response_body, response.code

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -1,105 +1,125 @@
-import json
-import mock
-import pytest
-import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from tornado.testing import gen_test
+
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class CopyDirHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return CopyDirHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("copydir"),
-            CopyDirHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE))
-    ])
-    return application
+    @gen_test
+    def test_post_returns_401_when_no_credentials_given(self):
+        self.assert_post_returns_401_when_no_credentials_given()
 
+    @gen_test
+    def test_post_returns_401_when_invalid_credentials_given(self):
+        self.assert_post_returns_401_when_invalid_credentials_given()
 
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/copydir/", "/copydir"])
-def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Transfer successful",
-                                                           "new files uploaded": 1,
-                                                           "files updated": 0,
-                                                           "files skipped": 0,
-                                                           "data transferred (bytes)": 100}
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory/some_sub_dir"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files uploaded': 1,
-                                     'files updated': 0,
-                                     'files skipped': 0,
-                                     'data transferred (bytes)': 100}
+    @gen_test
+    def test_post_returns_200_when_credentials_accepted(self):
+        self.assert_post_returns_200_when_credentials_accepted()
 
+    # Coupling with Data Replication Service
 
-@pytest.mark.gen_test
-def test_post_has_coupling_with_return_handler(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_transfer_summary(1, 0, 0, 100, "Transfer successful")
-    # Act
-    url = base_url + "/copydir/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory/some_sub_dir"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files uploaded': 1,
-                                     'files updated': 0,
-                                     'files skipped': 0,
-                                     'data transferred (bytes)': 100}
+    @gen_test
+    def test_post_returns_summary_of_single_object_transferred_when_successful(self):
+        # Arrange
+        transfer_summary = {
+            "message": "Transfer successful",
+            "new files uploaded": 1,
+            "files updated": 0,
+            "files skipped": 0,
+            "data transferred (bytes)": 100
+        }
+        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_dir.assert_called_once_with("test-bucket", "test_dir/test_sub_dir")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_successful_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message='Transfer successful',
+            new_files_uploaded=1,
+            files_updated=0,
+            files_skipped=0,
+            data_transferred=100
+        )
+        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = {"message": "Directory already exists, 5 files skipped",
-                                                           "new files uploaded": 0,
-                                                           "files updated": 0,
-                                                           "files skipped": 5,
-                                                           "data transferred (bytes)": 0}
-    # Act
-    url = base_url + "/copydir/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
-                                     'new files uploaded': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
+    @gen_test
+    def test_post_returns_summary_of_skipped_transfer_as_json(self):
+        # Arrange
+        transfer_summary = {
+            "message": "Directory already exists",
+            "new files uploaded": 0,
+            "files updated": 0,
+            "files skipped": 5,
+            "data transferred (bytes)": 0
+        }
+        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_dir.assert_called_once_with("test-bucket", "test_dir/test_sub_dir")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_skipped_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message="Directory already exists, 5 files skipped",
+            new_files_uploaded=0,
+            files_updated=0,
+            files_skipped=5,
+            data_transferred=0
+        )
+        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json_with_return_helper_coupling(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_dir.return_value = return_transfer_summary(
-        0, 0, 5, 0, "Directory already exists, 5 files skipped"
-    )
-    # Act
-    url = base_url + "/copydir/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
-                                     'new files uploaded': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
+    @gen_test
+    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
+        # Arrange
+        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
+        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        self.mock_data_replication_service.copy_dir.assert_called_once_with("test-bucket", "test_dir/test_sub_dir")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -118,7 +118,6 @@ class CopyDirHandlerTest(BaseHandlerTest):
         body = {'bucket': "test-bucket", 'directory': "test_dir/test_sub_dir"}
         response_body, response_code = yield self.send_authorised_POST_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
         self.mock_data_replication_service.copy_dir.assert_called_once_with("test-bucket", "test_dir/test_sub_dir")
         assert response_code == 200
         assert response_body['status'] == 'success'

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -119,7 +119,6 @@ class CopyNewHandlerTest(BaseHandlerTest):
         body = {'bucket': "test-bucket", }
         response_body, response_code = yield self.send_authorised_POST_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
         self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
         assert response_code == 200
         assert response_body['status'] == 'success'

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -1,115 +1,126 @@
-import json
-import mock
-import pytest
-import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from tornado.testing import gen_test
+
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class CopyNewHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return CopyNewHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("copynew"),
-            CopyNewHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE))
-    ])
-    return application
+    @gen_test
+    def test_post_returns_401_when_no_credentials_given(self):
+        self.assert_post_returns_401_when_no_credentials_given()
 
+    @gen_test
+    def test_post_returns_401_when_invalid_credentials_given(self):
+        self.assert_post_returns_401_when_invalid_credentials_given()
 
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/copynew/", "/copynew"])
-def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {'message': 'Transfer successful',
-                                                           'new files transferred': 1,
-                                                           'files updated': 0,
-                                                           'files skipped': 3,
-                                                           'data transferred (bytes)': 100}
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files transferred': 1,
-                                     'files updated': 0,
-                                     'files skipped': 3,
-                                     'data transferred (bytes)': 100}
+    @gen_test
+    def test_post_returns_200_when_credentials_accepted(self):
+        self.assert_post_returns_200_when_credentials_accepted()
 
+    # Coupling with Data Replication Service
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_transfer_as_json_when_successful_with_return_handler_coupling(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_transfer_summary(
-        message='Transfer successful',
-        new_files_uploaded=1,
-        files_updated=0,
-        files_skipped=3,
-        data_transferred=100
-    )
-    # Act
-    url = base_url + "/copynew/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files uploaded': 1,
-                                     'files updated': 0,
-                                     'files skipped': 3,
-                                     'data transferred (bytes)': 100}
+    @gen_test
+    def test_post_returns_summary_of_single_object_transferred_when_successful(self):
+        # Arrange
+        transfer_summary = {
+            'message': 'Transfer successful',
+            'new files transferred': 1,
+            'files updated': 0,
+            'files skipped': 3,
+            'data transferred (bytes)': 100
+        }
+        self.mock_data_replication_service.copy_new.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_successful_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message='Transfer successful',
+            new_files_uploaded=1,
+            files_updated=0,
+            files_skipped=3,
+            data_transferred=100
+        )
+        self.mock_data_replication_service.copy_new.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = {'message': "Directory already exists, 5 files skipped",
-                                                           'new files transferred': 0,
-                                                           'files updated': 0,
-                                                           'files skipped': 5,
-                                                           'data transferred (bytes)': 0}
-    # Act
-    url = base_url + "/copynew/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
-                                     'new files transferred': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
+    @gen_test
+    def test_post_returns_summary_of_skipped_transfer_as_json(self):
+        # Arrange
+        transfer_summary = {
+            "message": "objects returned successfully",
+            "objects": [
+                {"object": "file_1.txt", "bucket": "test-bucket"},
+                {"object": "file_2.txt", "bucket": "test-bucket"}
+            ]
+        }
+        self.mock_data_replication_service.copy_new.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_skipped_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message="Directory already exists, 5 files skipped",
+            new_files_uploaded=0,
+            files_updated=0,
+            files_skipped=5,
+            data_transferred=0
+        )
+        self.mock_data_replication_service.copy_new.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json_with_coupling_return_handler(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new.return_value = return_transfer_summary(
-        message="Directory already exists, 5 files skipped",
-        new_files_uploaded=0,
-        files_updated=0,
-        files_skipped=5,
-        data_transferred=0
-    )
-    # Act
-    url = base_url + "/copynew/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Directory already exists, 5 files skipped',
-                                     'new files uploaded': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
+    @gen_test
+    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
+        # Arrange
+        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
+        self.mock_data_replication_service.copy_new.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
@@ -1,117 +1,140 @@
-import json
-import mock
-import pytest
-import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from tornado.testing import gen_test
+
 from DittoWebApi.src.handlers.copy_update import CopyUpdateHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class CopyUpdateHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return CopyUpdateHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("copyupdate"),
-            CopyUpdateHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE)
+    @gen_test
+    def test_post_returns_401_when_no_credentials_given(self):
+        self.assert_post_returns_401_when_no_credentials_given()
+
+    @gen_test
+    def test_post_returns_401_when_invalid_credentials_given(self):
+        self.assert_post_returns_401_when_invalid_credentials_given()
+
+    @gen_test
+    def test_post_returns_200_when_credentials_accepted(self):
+        self.assert_post_returns_200_when_credentials_accepted()
+
+    # Coupling with Data Replication Service
+
+    @gen_test
+    def test_post_returns_summary_of_transfer_as_json_when_successful(self):
+        # Arrange
+        transfer_summary = {
+            'message': 'Transfer successful',
+            'new files uploaded': 2,
+            'files updated': 1,
+            'files skipped': 3,
+            'data transferred (bytes)': 100
+        }
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_new_and_update.assert_called_once_with("test-bucket", "some_directory")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
+
+    @gen_test
+    def test_post_successful_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message='Transfer successful',
+            new_files_uploaded=2,
+            files_updated=1,
+            files_skipped=3,
+            data_transferred=100
         )
-    ])
-    return application
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_returns_summary_of_skipped_transfer_as_json(self):
+        # Arrange
+        transfer_summary = {
+            'message': "No new or updated files found in directory",
+            'new files transferred': 0,
+            'files updated': 0,
+            'files skipped': 5,
+            'data transferred (bytes)': 0
+        }
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "test_dir"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.copy_new_and_update.assert_called_once_with("test-bucket", "test_dir")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/copyupdate/", "/copyupdate"])
-def test_post_returns_summary_of_transfer_as_json_when_successful(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new_and_update.return_value = {'message': 'Transfer successful',
-                                                                      'new files uploaded': 2,
-                                                                      'files updated': 1,
-                                                                      'files skipped': 3,
-                                                                      'data transferred (bytes)': 100}
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files uploaded': 2,
-                                     'files updated': 1,
-                                     'files skipped': 3,
-                                     'data transferred (bytes)': 100}
+    @gen_test
+    def test_post_skipped_transfer_summary_helper_coupled_with_method_schema(self):
+        # Arrange
+        transfer_summary = return_transfer_summary(
+            message="No new or updated files found in directory some_directory",
+            new_files_uploaded=0,
+            files_updated=0,
+            files_skipped=5,
+            data_transferred=0
+        )
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "bucket_1", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
+    @gen_test
+    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
+        # Arrange
+        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary
 
-@pytest.mark.gen_test
-def test_post_returns_summary_of_transfer_as_json_when_successful_with_return_handler_coupling(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new_and_update.return_value = return_transfer_summary(
-        message='Transfer successful',
-        new_files_uploaded=3,
-        files_updated=4,
-        files_skipped=7,
-        data_transferred=2560
-    )
-    # Act
-    url = base_url + "/copyupdate/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Transfer successful',
-                                     'new files uploaded': 3,
-                                     'files updated': 4,
-                                     'files skipped': 7,
-                                     'data transferred (bytes)': 2560}
-
-
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new_and_update.return_value = \
-        {'message': "No new or updated files found in directory some_directory",
-         'new files transferred': 0,
-         'files updated': 0,
-         'files skipped': 5,
-         'data transferred (bytes)': 0}
-    # Act
-    url = base_url + "/copyupdate/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'No new or updated files found in directory some_directory',
-                                     'new files transferred': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
-
-
-@pytest.mark.gen_test
-def test_post_returns_summary_of_failed_transfer_as_json_with_coupling_return_handler(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.copy_new_and_update.return_value = return_transfer_summary(
-        message="No new or updated files found in directory some_directory",
-        new_files_uploaded=0,
-        files_updated=0,
-        files_skipped=5,
-        data_transferred=0
-    )
-    # Act
-    url = base_url + "/copyupdate/"
-    body = json.dumps({'bucket': "bucket_1", 'directory': "some_directory"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'No new or updated files found in directory some_directory',
-                                     'new files uploaded': 0,
-                                     'files updated': 0,
-                                     'files skipped': 5,
-                                     'data transferred (bytes)': 0}
+    @gen_test
+    def test_post_returns_warning_when_directory_empty_or_nonexistent(self):
+        # Arrange
+        transfer_summary = {
+            "message": "No files found in directory or directory does not exist (some_directory)",
+            "objects": []
+        }
+        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == transfer_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -1,57 +1,85 @@
-import json
-import mock
-import pytest
-import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from tornado.testing import gen_test
+
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.utils.return_helper import return_bucket_message
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class CreateBucketHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return CreateBucketHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("createbucket"),
-            CreateBucketHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE)
-        )
-    ])
-    return application
+    @gen_test
+    def test_post_returns_401_when_no_credentials_given(self):
+        self.assert_post_returns_401_when_no_credentials_given()
 
+    @gen_test
+    def test_post_returns_401_when_invalid_credentials_given(self):
+        self.assert_post_returns_401_when_invalid_credentials_given()
 
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/createbucket/", "/createbucket"])
-def test_create_bucket_returns_summary_of_new_bucket_when_successful(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = return_bucket_message("Bucket Created (some-bucket)",
-                                                                                     "some-bucket")
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Bucket Created (some-bucket)',
-                                     'bucket': 'some-bucket'}
+    @gen_test
+    def test_post_returns_200_when_credentials_accepted(self):
+        self.assert_post_returns_200_when_credentials_accepted()
 
+    # Coupling with Data Replication Service
 
-@pytest.mark.gen_test
-def test_create_bucket_returns_summary_of_failure_when_bucket_already_exists(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.create_bucket.return_value = return_bucket_message(
-        "Bucket already exists (some-bucket)", "some-bucket"
-    )
-    # Act
-    url = base_url + "/createbucket/"
-    body = json.dumps({'bucket': "bucket_1"})
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'Bucket already exists (some-bucket)',
-                                     'bucket': 'some-bucket'}
+    @gen_test
+    def test_post_create_bucket_returns_summary_of_new_bucket_when_successful(self):
+        # Arrange
+        action_summary = {"message": "Bucket created", "bucket": "some-bucket"}
+        self.mock_data_replication_service.create_bucket.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.create_bucket.assert_called_once_with("test-bucket")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_post_create_bucket_successful_return_helper_coupled_with_method_schema(self):
+        # Arrange
+        action_summary = return_bucket_message("Bucket created", "some-bucket")
+        self.mock_data_replication_service.create_bucket.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'directory': "some_directory"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_post_create_bucket_reports_warning_as_json(self):
+        # Arrange
+        action_summary = {"message": "Bucket already exists", "bucket": "some-bucket"}
+        self.mock_data_replication_service.create_bucket.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.create_bucket.assert_called_once_with("test-bucket")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_post_create_bucket_reports_warning_coupled_with_method_schema(self):
+        # Arrange
+        action_summary = return_bucket_message("Bucket already exists", "some-bucket")
+        self.mock_data_replication_service.create_bucket.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket"}
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -35,7 +35,6 @@ class DeleteFileHandlerTest(BaseHandlerTest):
         with pytest.raises(tornado.httpclient.HTTPClientError) as error:
             yield self.send_authorised_DELETE_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
         assert error.value.response.code == 401
 
     @gen_test
@@ -47,7 +46,6 @@ class DeleteFileHandlerTest(BaseHandlerTest):
         body = {'bucket': "test-bucket", 'file': 'test.txt'}
         response_body, response_code = yield self.send_authorised_DELETE_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
         assert response_code == 200
         assert response_body['status'] == 'success'
 

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -1,60 +1,124 @@
-import json
-import mock
 import pytest
+from tornado.testing import gen_test
 import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class DeleteFileHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return DeleteFileHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("deletefile"),
-            DeleteFileHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE),
+    @gen_test
+    def test_delete_returns_401_when_no_credentials_given(self):
+        # Arrange
+        self.mock_security_service.check_credentials.return_value = False
+        # Act
+        body = {'bucket': "test-bucket", 'file': 'test.txt'}
+        with pytest.raises(tornado.httpclient.HTTPClientError) as error:
+            yield self.send_DELETE_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_not_called
+        assert error.value.response.code == 401
+
+    @gen_test
+    def test_delete_returns_401_when_invalid_credentials_given(self):
+        # Arrange
+        self.mock_security_service.check_credentials.return_value = False
+        # Act
+        body = {'bucket': "test-bucket", 'file': 'test.txt'}
+        with pytest.raises(tornado.httpclient.HTTPClientError) as error:
+            yield self.send_authorised_DELETE_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        assert error.value.response.code == 401
+
+    @gen_test
+    def test_delete_returns_200_when_credentials_accepted(self):
+        # Arrange
+        self.mock_data_replication_service.try_delete_file.return_value = {}
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'file': 'test.txt'}
+        response_body, response_code = yield self.send_authorised_DELETE_request(body)
+        # Assert
+        self.mock_security_service.check_credentials.assert_called_once_with(self.auth_username, self.auth_password)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+
+    # Coupling with Data Replication Service
+
+    @gen_test
+    def test_delete_file_returns_summary_of_deleted_files_as_json_when_successful(self):
+        # Arrange
+        action_summary = {
+            "message": "File successfully deleted",
+            "file": "test.txt",
+            "bucket": "test-bucket"
+        }
+        self.mock_data_replication_service.try_delete_file.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'file': "test.txt"}
+        response_body, response_code = yield self.send_authorised_DELETE_request(body)
+        # Assert
+        self.mock_data_replication_service.try_delete_file.assert_called_once_with("test-bucket", "test.txt")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_delete_file_successful_return_helper_coupled_with_method_schema(self):
+        # Arrange
+        action_summary = return_delete_file_helper("File successfully deleted", "test.txt", "test-bucket")
+        self.mock_data_replication_service.try_delete_file.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'file': "test.txt"}
+        response_body, response_code = yield self.send_authorised_DELETE_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_delete_file_reports_warning_as_json(self):
+        # Arrange
+        action_summary = {
+            "message": "File does not exist in the bucket",
+            "file": "test.txt",
+            "bucket": "test-bucket"
+        }
+        self.mock_data_replication_service.try_delete_file.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'file': "test.txt"}
+        response_body, response_code = yield self.send_authorised_DELETE_request(body)
+        # Assert
+        self.mock_data_replication_service.try_delete_file.assert_called_once_with("test-bucket", "test.txt")
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary
+
+    @gen_test
+    def test_delete_file_reports_warning_coupled_with_method_schema(self):
+        # Arrange
+        action_summary = return_delete_file_helper(
+            "File does not exist in the bucket",
+            "test.txt",
+            "test-bucket"
         )
-    ])
-    return application
-
-
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/deletefile/", "/deletefile"])
-def test_delete_returns_summary_of_deleted_files_as_json_when_successful(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = return_delete_file_helper(
-        "File some_file.txt, successfully deleted from bucket bucket_1", "some_file.txt", "bucket_1"
-    )
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1", 'file': "some_file.txt"})
-    response = yield http_client.fetch(url, method="DELETE", body=body, allow_nonstandard_methods=True)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'File some_file.txt, successfully deleted from bucket bucket_1',
-                                     'file': 'some_file.txt',
-                                     'bucket': 'bucket_1'}
-
-
-@pytest.mark.gen_test
-def test_delete_returns_summary_of_failed_delete_as_json_when_unsuccessful(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.try_delete_file.return_value = return_delete_file_helper(
-        "File some_file.txt does not exist in bucket bucket_1", "some_file.txt", "bucket_1"
-    )
-    # Act
-    url = base_url + "/deletefile/"
-    body = json.dumps({'bucket': "bucket_1", 'file': "some_file.txt"})
-    response = yield http_client.fetch(url, method="DELETE", body=body, allow_nonstandard_methods=True)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"] == {'message': 'File some_file.txt does not exist in bucket bucket_1',
-                                     'file': 'some_file.txt',
-                                     'bucket': 'bucket_1'}
+        self.mock_data_replication_service.try_delete_file.return_value = action_summary
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", 'file': "test.txt"}
+        response_body, response_code = yield self.send_authorised_DELETE_request(body)
+        # Assert
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == action_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
@@ -1,92 +1,100 @@
-import json
-import mock
-import pytest
-import tornado.web
-from DittoWebApi.src.services.data_replication.data_replication_service import DataReplicationService
+from tornado.testing import gen_test
+
 from DittoWebApi.src.handlers.list_present import ListPresentHandler
-from DittoWebApi.src.utils.route_helper import format_route_specification
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
-MOCK_DATA_REPLICATION_SERVICE = mock.create_autospec(DataReplicationService)
+class ListPresentHandlerTest(BaseHandlerTest):
+    @property
+    def handler(self):
+        return ListPresentHandler
 
+    # Security
 
-@pytest.fixture(autouse=True)
-def app():
-    application = tornado.web.Application([
-        (
-            format_route_specification("listpresent"),
-            ListPresentHandler,
-            dict(data_replication_service=MOCK_DATA_REPLICATION_SERVICE)
-        )
-    ])
-    return application
+    @gen_test
+    def test_post_returns_401_when_no_credentials_given(self):
+        self.assert_post_returns_401_when_no_credentials_given()
 
+    @gen_test
+    def test_post_returns_401_when_invalid_credentials_given(self):
+        self.assert_post_returns_401_when_invalid_credentials_given()
 
-@pytest.mark.gen_test
-@pytest.mark.parametrize("route", ["/listpresent/", "/listpresent"])
-def test_post_returns_objects_from_server_as_json(http_client, base_url, route):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.retrieve_object_dicts.return_value = {"message": "objects returned succesfully",
-                                                                        "objects": [{"object_name": "file_1.txt",
-                                                                                     "bucket_name": "bucket_1"}]}
-    # Act
-    url = base_url + route
-    body = json.dumps({'bucket': "bucket_1", })
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"]["objects"] == [{"object_name": "file_1.txt", "bucket_name": "bucket_1"}]
-    assert response_body["data"]["message"] == "objects returned succesfully"
+    @gen_test
+    def test_post_returns_200_when_credentials_accepted(self):
+        self.assert_post_returns_200_when_credentials_accepted()
 
+    # Coupling with Data Replication Service
 
-@pytest.mark.gen_test
-def test_post_returns_multiple_objects_as_a_json_array(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.retrieve_object_dicts.return_value = {"message": "objects returned succesfully",
-                                                                        "objects": [{"object": "file_1.txt",
-                                                                                     "bucket": "bucket_1"},
-                                                                                    {"object": "file_2.txt",
-                                                                                     "bucket": "bucket_1"}]}
-    # Act
-    url = base_url + "/listpresent/"
-    body = json.dumps({'bucket': "bucket_1", })
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"]["objects"] == [{"object": "file_1.txt", "bucket": "bucket_1"},
-                                                {"object": "file_2.txt", "bucket": "bucket_1"}]
-    assert response_body["data"]["message"] == "objects returned succesfully"
+    @gen_test
+    def test_post_returns_single_object_in_json_array(self):
+        # Arrange
+        object_dicts = {
+            "message": "objects returned successfully",
+            "objects": [
+                {"object": "file_1.txt", "bucket": "test-bucket"}
+            ]
+        }
+        self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.retrieve_object_dicts.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == object_dicts
 
+    @gen_test
+    def test_post_returns_multiple_objects_as_a_json_array(self):
+        # Arrange
+        object_dicts = {
+            "message": "objects returned successfully",
+            "objects": [
+                {"object": "file_1.txt", "bucket": "test-bucket"},
+                {"object": "file_2.txt", "bucket": "test-bucket"}
+            ]
+        }
+        self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.retrieve_object_dicts.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == object_dicts
 
-@pytest.mark.gen_test
-def test_post_returns_empty_array_when_no_objects(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.retrieve_object_dicts.return_value = {"message": "no objects in s3 bucket",
-                                                                        "objects": []}
-    # Act
-    url = base_url + "/listpresent/"
-    body = json.dumps({'bucket': "bucket_1", })
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"]["objects"] == []
-    assert response_body["data"]["message"] == "no objects in s3 bucket"
+    @gen_test
+    def test_post_returns_empty_array_when_no_objects(self):
+        # Arrange
+        object_dicts = {
+            "message": "no objects in S3 bucket",
+            "objects": []
+        }
+        self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.retrieve_object_dicts.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == object_dicts
 
-
-@pytest.mark.gen_test
-def test_post_returns_warning_when_invalid_bucket_name_provided(http_client, base_url):
-    # Arrange
-    MOCK_DATA_REPLICATION_SERVICE.retrieve_object_dicts.return_value = {"message": "bucket_1 does not exist in S3",
-                                                                        "objects": []}
-    # Act
-    url = base_url + "/listpresent/"
-    body = json.dumps({'bucket': "bucket_1", })
-    response = yield http_client.fetch(url, method="POST", body=body)
-    # Assert
-    response_body = json.loads(response.body, encoding='utf-8')
-    assert response_body["status"] == "success"
-    assert response_body["data"]["objects"] == []
-    assert response_body["data"]["message"] == "bucket_1 does not exist in S3"
+    @gen_test
+    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
+        # Arrange
+        object_dicts = {"message": "test-bucket does not exist in S3", "objects": []}
+        self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
+        self.mock_security_service.check_credentials.return_value = True
+        # Act
+        body = {'bucket': "test-bucket", }
+        response_body, response_code = yield self.send_authorised_POST_request(body)
+        # Assert
+        self.mock_data_replication_service.retrieve_object_dicts.assert_called_once_with("test-bucket", None)
+        assert response_code == 200
+        assert response_body['status'] == 'success'
+        assert response_body['data'] == object_dicts

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -259,16 +259,17 @@ class DataReplicationServiceTest(unittest.TestCase):
 
     def test_try_delete_file_returns_warning_message_when_bucket_doesnt_exist(self):
         # Arrange
-        bucket_name = "bucket-1"
+        bucket_name = "test-bucket"
+        file_rel_path = "test.txt"
         self.mock_external_data_service.does_bucket_exist.return_value = False
         # Act
-        response = self.test_service.try_delete_file(bucket_name, "some_file")
+        response = self.test_service.try_delete_file(bucket_name, file_rel_path)
         # Assert
-        self.mock_logger.warning.assert_called_with("Warning, bucket does not exist (bucket-1)")
+        self.mock_logger.warning.assert_called_with("Warning, bucket does not exist (test-bucket)")
         assert response == return_delete_file_helper(
-            bucket_name='bucket-1',
-            file_name='some_file',
-            message='Warning, bucket does not exist (bucket-1)'
+            bucket_name=bucket_name,
+            file_rel_path=file_rel_path,
+            message='Warning, bucket does not exist (test-bucket)'
         )
 
     def test_try_delete_file_returns_error_message_when_file_doesnt_exist(self):

--- a/ditto_web_api/DittoWebApi/tests/utils/str2list_tests.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/str2list_tests.py
@@ -7,4 +7,3 @@ from DittoWebApi.src.utils.parse_strings import str2list
 def test_str2list_splits_any_padded_string_with_default_settings(string):
     result = str2list(string)
     assert result == ["a", "1", "foobar"]
-

--- a/ditto_web_api/DittoWebApi/tests/utils/str2list_tests.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/str2list_tests.py
@@ -1,0 +1,10 @@
+import pytest
+
+from DittoWebApi.src.utils.parse_strings import str2list
+
+
+@pytest.mark.parametrize("string", ["a,1,foobar", "a, 1, foobar", "a,   1, foobar", ])
+def test_str2list_splits_any_padded_string_with_default_settings(string):
+    result = str2list(string)
+    assert result == ["a", "1", "foobar"]
+


### PR DESCRIPTION
* All handlers now inherit from `DittoHandler`
  - This checks authorization credentials
  - Logic for reading in body attributes is tidied away here also
* Interface for a security service (`ISecurityService`) to be implemented by UKAEA according to their back-office systems
  - Placeholder `ConfigSecurityService` written purely for development purposes (**NOT FOR DEPLOYMENT**)
* Handler unit tests adapted to `AsyncHTTPTestCase`
* Change in nomenclature for deleting a file: `file_rel_path` is the identifier, not `file_name`