### PR TITLE
Write security file on system startup for system tests

### DIFF
--- a/systemTests/testScenarios/given/ditto_api_server.py
+++ b/systemTests/testScenarios/given/ditto_api_server.py
@@ -40,7 +40,7 @@ class DittoApiServer:
 
     def _write_security(self):
         file_contents = \
-            f'[{self._context.username}]\n' \
+            f'[{self._context.authentication_username}]\n' \
             f'password = {self._context.authentication_password}\n' \
             f'groups = {self._context.authentication_groups}\n'
 

--- a/systemTests/testScenarios/given/ditto_api_server.py
+++ b/systemTests/testScenarios/given/ditto_api_server.py
@@ -9,6 +9,7 @@ class DittoApiServer:
 
     def is_started(self):
         self._write_configuration()
+        self._write_security()
         self._start_ditto()
 
     def is_started_without_configuration(self):


### PR DESCRIPTION
Bug fix for security configuration not being written on startup
#72 