### PR TITLE
Feature/status codes and status reflect failed requests/#71

### DIFF
--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
@@ -25,4 +25,7 @@ class CopyDirHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
+        exceptions.api_assert(result["message"] == "Transfer successful",
+                              400,
+                              result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -27,8 +27,8 @@ class CopyDirHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
-
-        exceptions.api_assert(result["message"] in positive_responses(dir_path),
-                              400,
-                              result["message"])
+        exceptions.api_assert(result["status"].value == 200,
+                              result["status"].value,
+                              result['message'])
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -27,7 +27,8 @@ class CopyDirHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] in positive_responses(),
+
+        exceptions.api_assert(result["message"] in positive_responses(dir_path),
                               400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -3,7 +3,6 @@ from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
-from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyDirHandler(DittoHandler):

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -27,8 +27,6 @@ class CopyDirHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
-        exceptions.api_assert(result["status"].value == 200,
-                              result["status"].value,
-                              result['message'])
+        self.check_request_was_completed_successfully(result)
         del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_dir.py
@@ -3,6 +3,7 @@ from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
+from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyDirHandler(DittoHandler):
@@ -25,7 +26,7 @@ class CopyDirHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_dir(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] == "Transfer successful",
+        exceptions.api_assert(result["message"] in positive_responses(),
                               400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -3,6 +3,7 @@ from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
+from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyNewHandler(DittoHandler):
@@ -25,7 +26,7 @@ class CopyNewHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] == "Transfer successful",
+        exceptions.api_assert(result["message"] in positive_responses(dir_path),
                               400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
@@ -25,4 +25,7 @@ class CopyNewHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new(bucket_name, dir_path)
+        exceptions.api_assert(result["message"] == "Transfer successful",
+                              400,
+                              result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_new.py
@@ -3,7 +3,6 @@ from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
-from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyNewHandler(DittoHandler):
@@ -27,7 +26,6 @@ class CopyNewHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] in positive_responses(dir_path),
-                              400,
-                              result["message"])
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -28,8 +28,6 @@ class CopyUpdateHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new_and_update(bucket_name, dir_path)
-        
-        exceptions.api_assert(result["message"] in positive_responses(dir_path),
-                              400,
-                              result["message"])
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -1,9 +1,8 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
-from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyUpdateHandler(DittoHandler):

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
@@ -26,4 +26,7 @@ class CopyUpdateHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new_and_update(bucket_name, dir_path)
+        exceptions.api_assert(result["message"] == "Transfer successful",
+                              400,
+                              result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -28,7 +28,8 @@ class CopyUpdateHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new_and_update(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] in positive_responses(),
+        
+        exceptions.api_assert(result["message"] in positive_responses(dir_path),
                               400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/copy_update.py
@@ -3,6 +3,7 @@ from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_transfer_output_schema
+from DittoWebApi.src.utils.messages import positive_responses
 
 
 class CopyUpdateHandler(DittoHandler):
@@ -26,7 +27,7 @@ class CopyUpdateHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.copy_new_and_update(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] == "Transfer successful",
+        exceptions.api_assert(result["message"] in positive_responses(),
                               400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -23,7 +23,6 @@ class CreateBucketHandler(DittoHandler):
     def post(self, *args, **kwargs):
         bucket_name = self.get_body_attribute("bucket", required=True)
         result = self._data_replication_service.create_bucket(bucket_name)
-        exceptions.api_assert("Bucket Created" in result["message"],
-                              400,
-                              result["message"])
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 
@@ -23,4 +23,7 @@ class CreateBucketHandler(DittoHandler):
     def post(self, *args, **kwargs):
         bucket_name = self.get_body_attribute("bucket", required=True)
         result = self._data_replication_service.create_bucket(bucket_name)
+        exceptions.api_assert("Bucket Created" in result["message"],
+                              400,
+                              result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/create_bucket.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -24,6 +24,6 @@ class DeleteFileHandler(DittoHandler):
         file_rel_path = self.get_body_attribute("file", required=True)
         result = self._data_replication_service.try_delete_file(bucket_name, file_rel_path)
         exceptions.api_assert("successfully deleted from bucket" in result["message"],
-                              404,
+                              400,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 
@@ -23,4 +23,7 @@ class DeleteFileHandler(DittoHandler):
         bucket_name = self.get_body_attribute("bucket", required=True)
         file_rel_path = self.get_body_attribute("file", required=True)
         result = self._data_replication_service.try_delete_file(bucket_name, file_rel_path)
+        exceptions.api_assert("successfully deleted from bucket" in result["message"],
+                              404,
+                              result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 

--- a/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/delete_file.py
@@ -24,7 +24,6 @@ class DeleteFileHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         file_rel_path = self.get_body_attribute("file", required=True)
         result = self._data_replication_service.try_delete_file(bucket_name, file_rel_path)
-        exceptions.api_assert("successfully deleted from bucket" in result["message"],
-                              400,
-                              result["message"])
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -1,6 +1,7 @@
 from base64 import b64decode
 
 from tornado_json.requesthandlers import APIHandler
+from tornado_json import exceptions
 
 
 class DittoHandler(APIHandler):
@@ -38,5 +39,4 @@ class DittoHandler(APIHandler):
             self._authentication_failed()
 
     def _authentication_failed(self):
-        self.set_status(401)
-        self.finish({'reason': 'Authentication required'})
+        raise exceptions.APIError(401, 'Authentication required')

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -48,10 +48,12 @@ class DittoHandler(APIHandler):
         else:
             self._authentication_failed()
 
-    def check_request_was_completed_successfully(self, result):
+    @staticmethod
+    def check_request_was_completed_successfully(result):
         exceptions.api_assert(result["status"].value == 200,
                               result["status"].value,
                               result['message'])
 
-    def _authentication_failed(self):
+    @staticmethod
+    def _authentication_failed():
         raise exceptions.APIError(401, 'Authentication required')

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -48,5 +48,10 @@ class DittoHandler(APIHandler):
         else:
             self._authentication_failed()
 
+    def check_request_was_completed_successfully(self, result):
+        exceptions.api_assert(result["status"].value == 200,
+                              result["status"].value,
+                              result['message'])
+
     def _authentication_failed(self):
         raise exceptions.APIError(401, 'Authentication required')

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -19,12 +19,12 @@ class DittoHandler(APIHandler):
         if key in self.body:
             return self.body[key]
         if required:
-            raise ValueError('Attribute missing')
+            raise exceptions.APIError(400, 'Attribute missing')
         return default
 
     def check_current_user_authorised_for_bucket(self, bucket_name):
         if not self._bucket_settings_service.is_bucket_recognised(bucket_name):
-            raise exceptions.APIError(404, 'Not authorised for this bucket')
+            raise exceptions.APIError(404, 'Bucket does not exist')
         permitted_groups = self._bucket_settings_service.bucket_permitted_groups(bucket_name)
         for group_name in permitted_groups:
             if self._security_service.is_in_group(self._current_user, group_name):

--- a/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/ditto_handler.py
@@ -24,14 +24,12 @@ class DittoHandler(APIHandler):
 
     def check_current_user_authorised_for_bucket(self, bucket_name):
         if not self._bucket_settings_service.is_bucket_recognised(bucket_name):
-            self.set_status(404)
-            self.finish({'reason': 'Bucket name not recognised'})
+            raise exceptions.APIError(404, 'Not authorised for this bucket')
         permitted_groups = self._bucket_settings_service.bucket_permitted_groups(bucket_name)
         for group_name in permitted_groups:
             if self._security_service.is_in_group(self._current_user, group_name):
                 return
-        self.set_status(403)
-        self.finish({'reason': 'Not authorised for this bucket'})
+        raise exceptions.APIError(403, 'Not authorised for this bucket')
 
     def _check_credentials(self):
         auth_header = self.request.headers.get('Authorization')

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema, exceptions
+from tornado_json import schema
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_list_present_output_schema

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -1,5 +1,5 @@
 # pylint: disable=W0221,W0223
-from tornado_json import schema
+from tornado_json import schema, exceptions
 from DittoWebApi.src.handlers.ditto_handler import DittoHandler
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_object_schema_with_string_properties
 from DittoWebApi.src.handlers.schemas.schema_helpers import create_list_present_output_schema
@@ -22,5 +22,8 @@ class ListPresentHandler(DittoHandler):
     def post(self, *args, **kwargs):
         bucket_name = self.get_body_attribute("bucket", required=True)
         dir_path = self.get_body_attribute("directory", default=None)
-        object_dicts = self._data_replication_service.retrieve_object_dicts(bucket_name, dir_path)
-        return object_dicts
+        result = self._data_replication_service.retrieve_object_dicts(bucket_name, dir_path)
+        exceptions.api_assert(result["message"] == "objects returned successfully",
+                              400,
+                              result["message"])
+        return result

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -24,7 +24,6 @@ class ListPresentHandler(DittoHandler):
         self.check_current_user_authorised_for_bucket(bucket_name)
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.retrieve_object_dicts(bucket_name, dir_path)
-        exceptions.api_assert(result["message"] == "objects returned successfully",
-                              404,
-                              result["message"])
+        self.check_request_was_completed_successfully(result)
+        del result['status']
         return result

--- a/ditto_web_api/DittoWebApi/src/handlers/list_present.py
+++ b/ditto_web_api/DittoWebApi/src/handlers/list_present.py
@@ -24,6 +24,6 @@ class ListPresentHandler(DittoHandler):
         dir_path = self.get_body_attribute("directory", default=None)
         result = self._data_replication_service.retrieve_object_dicts(bucket_name, dir_path)
         exceptions.api_assert(result["message"] == "objects returned successfully",
-                              400,
+                              404,
                               result["message"])
         return result

--- a/ditto_web_api/DittoWebApi/src/services/bucket_settings_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/bucket_settings_service.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 
+from tornado_json import exceptions
 from DittoWebApi.src.utils.parse_strings import str2list
 
 
@@ -39,10 +40,10 @@ class BucketSettingsService:
         if bucket_name in self._settings:
             return self._settings[bucket_name].root_dir
         self._logger.warning(f'Root directory requested for non-existent bucket "{bucket_name}"')
-        raise ValueError(f'Bucket "{bucket_name}" does not exist')
+        raise exceptions.APIError(404, f'Bucket "{bucket_name}" does not exist')
 
     def bucket_permitted_groups(self, bucket_name):
         if bucket_name in self._settings:
             return self._settings[bucket_name].groups
         self._logger.warning(f'Permitted groups requested for non-existent bucket "{bucket_name}"')
-        raise ValueError(f'Bucket "{bucket_name}" does not exist')
+        raise exceptions.APIError(404, f'Bucket "{bucket_name}" does not exist')

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/bucket_validator.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/bucket_validator.py
@@ -1,6 +1,7 @@
 from DittoWebApi.src.utils import messages
 from DittoWebApi.src.utils.bucket_helper import is_valid_bucket
-
+from DittoWebApi.src.utils.bucket_warning import BucketWarning
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 # pylint: disable=too-few-public-methods
 class BucketValidator:
@@ -13,13 +14,13 @@ class BucketValidator:
         bucket_warning = None
 
         if not is_valid_bucket(bucket_name):
-            bucket_warning = messages.bucket_breaks_s3_convention(bucket_name)
+            bucket_warning = BucketWarning(messages.bucket_breaks_s3_convention(bucket_name), StatusCodes.Bad_request)
 
         elif not self._external_data_service.does_bucket_match_standard(bucket_name):
-            bucket_warning = messages.bucket_breaks_config(bucket_name)
+            bucket_warning = BucketWarning(messages.bucket_breaks_config(bucket_name), StatusCodes.Bad_request)
 
         elif not self._external_data_service.does_bucket_exist(bucket_name):
-            bucket_warning = messages.bucket_not_exists(bucket_name)
+            bucket_warning = BucketWarning(messages.bucket_not_exists(bucket_name), StatusCodes.Not_found)
 
         if bucket_warning is not None:
             self._logger.warning(bucket_warning)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/bucket_validator.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/bucket_validator.py
@@ -3,6 +3,7 @@ from DittoWebApi.src.utils.bucket_helper import is_valid_bucket
 from DittoWebApi.src.utils.bucket_warning import BucketWarning
 from DittoWebApi.src.utils.return_status import StatusCodes
 
+
 # pylint: disable=too-few-public-methods
 class BucketValidator:
     def __init__(self, external_data_service, logger):

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -34,6 +34,8 @@ class DataReplicationService:
             return {"message": bucket_warning, "objects": []}
         objects = self._external_data_service.get_objects(bucket_name, dir_path)
         object_dicts = [obj.to_dict() for obj in objects]
+        if not object_dicts:
+            return {"message": f"no objects in directory {dir_path} in bucket {bucket_name}"}
         return {"message": "objects returned successfully", "objects": object_dicts}
 
     def copy_dir(self, bucket_name, dir_path):

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -6,6 +6,7 @@ from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHel
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
+from DittoWebApi.src.utils.return_helper import return_list_present_helper
 from DittoWebApi.src.utils.return_status import StatusCodes
 
 
@@ -28,12 +29,17 @@ class DataReplicationService:
         self._logger.debug("Called list-present handler")
         bucket_warning = self._bucket_validator.check_bucket(bucket_name)
         if bucket_warning is not None:
-            return {"message": bucket_warning, "objects": []}
+            return return_list_present_helper(message=bucket_warning.message, objects=[], status=bucket_warning.status)
         objects = self._external_data_service.get_objects(bucket_name, dir_path)
         object_dicts = [obj.to_dict() for obj in objects]
         if not object_dicts:
-            return {"message": f"no objects in directory {dir_path} in bucket {bucket_name}"}
-        return {"message": "objects returned successfully", "objects": object_dicts}
+            return return_list_present_helper(
+                message=f"no objects in directory {dir_path} in bucket {bucket_name}",
+                objects=[],
+                status=StatusCodes.Okay)
+        return return_list_present_helper(message="objects returned successfully",
+                                          objects=object_dicts,
+                                          status=StatusCodes.Okay)
 
     def copy_dir(self, bucket_name, dir_path):
         self._logger.debug("Called copy-dir handler")
@@ -56,7 +62,7 @@ class DataReplicationService:
             warning = messages.directory_exists(directory, len(files_in_directory))
             self._logger.warning(warning)
             return return_transfer_summary(
-                message=warning, files_skipped=len(files_in_directory), status=StatusCodes.Bad_request)
+                message=warning, files_skipped=len(files_in_directory))
 
         file_summary = self._storage_difference_processor.return_difference_comparison([], files_in_directory)
         transfer_summary = self._external_data_service.perform_transfer(bucket_name, file_summary)
@@ -68,20 +74,21 @@ class DataReplicationService:
         if not bucket_name:
             warning = messages.no_bucket_name()
             self._logger.warning(warning)
-            return return_bucket_message(warning)
+            return return_bucket_message(warning, status=StatusCodes.Bad_request)
 
         if not self._external_data_service.does_bucket_match_standard(bucket_name):
             message = messages.bucket_breaks_config(bucket_name)
             self._logger.info(message)
-            return return_bucket_message(message, bucket_name)
+            return return_bucket_message(message, bucket_name, status=StatusCodes.Bad_request)
 
         if self._external_data_service.does_bucket_exist(bucket_name):
             warning = messages.bucket_already_exists(bucket_name)
             self._logger.warning(warning)
-            return return_bucket_message(warning, bucket_name)
+            return return_bucket_message(warning, bucket_name, status=StatusCodes.Bad_request)
 
         if is_valid_bucket(bucket_name) is False:
-            return return_bucket_message(messages.bucket_breaks_s3_convention(bucket_name), bucket_name)
+            return return_bucket_message(
+                messages.bucket_breaks_s3_convention(bucket_name), bucket_name, status=StatusCodes.Bad_request)
         self._external_data_service.create_bucket(bucket_name)
         return return_bucket_message(messages.bucket_created(bucket_name), bucket_name)
 
@@ -89,16 +96,18 @@ class DataReplicationService:
         self._logger.debug("Called delete-file handler")
         bucket_warning = self._bucket_validator.check_bucket(bucket_name)
         if bucket_warning is not None:
-            return return_delete_file_helper(message=bucket_warning,
+            return return_delete_file_helper(message=bucket_warning.message,
                                              file_rel_path=file_rel_path,
-                                             bucket_name=bucket_name)
+                                             bucket_name=bucket_name,
+                                             status=bucket_warning.status)
 
         if not self._external_data_service.does_object_exist(bucket_name, file_rel_path):
             warning = messages.file_existence_warning(file_rel_path, bucket_name)
             self._logger.warning(warning)
             return return_delete_file_helper(message=warning,
                                              file_rel_path=file_rel_path,
-                                             bucket_name=bucket_name)
+                                             bucket_name=bucket_name,
+                                             status=StatusCodes.Not_found)
         self._external_data_service.delete_file(bucket_name, file_rel_path)
         msg = messages.file_deleted(file_rel_path, bucket_name)
         action_summary = return_delete_file_helper(message=msg, file_rel_path=file_rel_path, bucket_name=bucket_name)
@@ -108,7 +117,7 @@ class DataReplicationService:
         self._logger.debug("Called copy new handler")
         bucket_warning = self._bucket_validator.check_bucket(bucket_name)
         if bucket_warning is not None:
-            return return_transfer_summary(message=bucket_warning)
+            return return_transfer_summary(message=bucket_warning.message, status=bucket_warning.status)
         directory = dir_path if dir_path else "root"
         root_dir = self._bucket_settings_service.bucket_root_directory(bucket_name)
         files_in_directory = self._internal_data_service.find_files(root_dir, dir_path)
@@ -116,7 +125,7 @@ class DataReplicationService:
         if not files_in_directory:
             warning = messages.no_files_found(directory)
             self._logger.warning(warning)
-            return return_transfer_summary(message=warning)
+            return return_transfer_summary(message=warning, status=StatusCodes.Not_found)
 
         objects_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         files_summary = self._storage_difference_processor.return_difference_comparison(
@@ -135,7 +144,7 @@ class DataReplicationService:
         self._logger.debug("Called copy-update handler")
         bucket_warning = self._bucket_validator.check_bucket(bucket_name)
         if bucket_warning is not None:
-            return return_transfer_summary(message=bucket_warning)
+            return return_transfer_summary(message=bucket_warning.message, status=bucket_warning.status)
 
         directory = dir_path if dir_path else "root"
         root_dir = self._bucket_settings_service.bucket_root_directory(bucket_name)
@@ -144,12 +153,11 @@ class DataReplicationService:
         if not files_in_directory:
             warning = messages.no_files_found(directory)
             self._logger.warning(warning)
-            return return_transfer_summary(message=warning)
+            return return_transfer_summary(message=warning, status=StatusCodes.Not_found)
 
         objects_already_in_bucket = self._external_data_service.get_objects(bucket_name, dir_path)
         files_summary = self._storage_difference_processor.return_difference_comparison(
-            objects_already_in_bucket, files_in_directory, check_for_updates=True
-        )
+            objects_already_in_bucket, files_in_directory, check_for_updates=True)
 
         if not files_summary.new_files and not files_summary.updated_files:
             message = messages.no_new_or_updates(directory)

--- a/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/data_replication/data_replication_service.py
@@ -6,6 +6,7 @@ from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHel
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class DataReplicationService:
@@ -39,7 +40,7 @@ class DataReplicationService:
 
         bucket_warning = self._bucket_validator.check_bucket(bucket_name)
         if bucket_warning is not None:
-            return return_transfer_summary(message=bucket_warning)
+            return return_transfer_summary(message=bucket_warning, status=StatusCodes.Bad_request)
 
         root_dir = self._bucket_settings_service.bucket_root_directory(bucket_name)
         files_in_directory = self._internal_data_service.find_files(root_dir, dir_path)

--- a/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
@@ -3,6 +3,7 @@ import dateutil.parser
 from DittoWebApi.src.models.s3_object_information import S3ObjectInformation
 from DittoWebApi.src.utils.file_system.path_helpers import to_posix
 from DittoWebApi.src.utils.file_system.path_helpers import dir_path_as_prefix
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class ExternalDataService:
@@ -143,4 +144,5 @@ class ExternalDataService:
                 "new_files_uploaded": len(file_summary.new_files),
                 "files_updated": len(file_summary.updated_files),
                 "files_skipped": len(file_summary.files_to_be_skipped()),
-                "data_transferred": data_transferred}
+                "data_transferred": data_transferred,
+                "status": StatusCodes.Okay}

--- a/ditto_web_api/DittoWebApi/src/utils/bucket_warning.py
+++ b/ditto_web_api/DittoWebApi/src/utils/bucket_warning.py
@@ -1,0 +1,4 @@
+class BucketWarning:
+    def __init__(self, message, status):
+        self.message = message
+        self.status = status

--- a/ditto_web_api/DittoWebApi/src/utils/messages.py
+++ b/ditto_web_api/DittoWebApi/src/utils/messages.py
@@ -64,10 +64,3 @@ def bucket_not_exists(bucket_name):
 
 def no_new_or_updates(directory):
     return "No new or updated files found in directory ({})".format(directory)
-
-
-def positive_responses(dir_path):
-    directory = dir_path if dir_path else "root"
-    return [no_new_or_updates(directory),
-            transfer_success(),
-            no_new_files(directory)]

--- a/ditto_web_api/DittoWebApi/src/utils/messages.py
+++ b/ditto_web_api/DittoWebApi/src/utils/messages.py
@@ -64,3 +64,10 @@ def bucket_not_exists(bucket_name):
 
 def no_new_or_updates(directory):
     return "No new or updated files found in directory ({})".format(directory)
+
+
+def positive_responses(dir_path):
+    directory = dir_path if dir_path else "root"
+    return [no_new_or_updates(directory),
+            transfer_success(),
+            no_new_files(directory)]

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -1,9 +1,14 @@
-def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped=0, data_transferred=0, message=""):
+from DittoWebApi.src.utils.return_status import StatusCodes
+
+status_codes = StatusCodes()
+
+def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped=0, data_transferred=0, status=status_codes.Okay, message=""):
     return {"message": message,
             "new files uploaded": new_files_uploaded,
             "files updated": files_updated,
             "files skipped": files_skipped,
-            "data transferred (bytes)": data_transferred}
+            "data transferred (bytes)": data_transferred,
+            "status": status}
 
 
 def return_bucket_message(message, bucket_name=""):

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -1,8 +1,7 @@
 from DittoWebApi.src.utils.return_status import StatusCodes
 
-status_codes = StatusCodes()
 
-def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped=0, data_transferred=0, status=status_codes.Okay, message=""):
+def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped=0, data_transferred=0, status=StatusCodes.Okay, message=""):
     return {"message": message,
             "new files uploaded": new_files_uploaded,
             "files updated": files_updated,

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -10,12 +10,20 @@ def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped
             "status": status}
 
 
-def return_bucket_message(message, bucket_name=""):
+def return_bucket_message(message, bucket_name="", status=StatusCodes.Okay):
     return {"message": message,
-            "bucket": bucket_name}
+            "bucket": bucket_name,
+            "status": status}
 
 
-def return_delete_file_helper(message, file_rel_path, bucket_name):
+def return_delete_file_helper(message, file_rel_path, bucket_name, status=StatusCodes.Okay):
     return {"message": message,
             "file": file_rel_path,
-            "bucket": bucket_name}
+            "bucket": bucket_name,
+            "status": status}
+
+
+def return_list_present_helper(message, objects, status=StatusCodes.Okay):
+    return {"message": message,
+            "objects": objects,
+            "status": status}

--- a/ditto_web_api/DittoWebApi/src/utils/return_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_helper.py
@@ -1,7 +1,13 @@
 from DittoWebApi.src.utils.return_status import StatusCodes
 
 
-def return_transfer_summary(new_files_uploaded=0, files_updated=0, files_skipped=0, data_transferred=0, status=StatusCodes.Okay, message=""):
+def return_transfer_summary(
+        new_files_uploaded=0,
+        files_updated=0,
+        files_skipped=0,
+        data_transferred=0,
+        status=StatusCodes.Okay,
+        message=""):
     return {"message": message,
             "new files uploaded": new_files_uploaded,
             "files updated": files_updated,

--- a/ditto_web_api/DittoWebApi/src/utils/return_status.py
+++ b/ditto_web_api/DittoWebApi/src/utils/return_status.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class StatusCodes(Enum):
+    Not_found = 404
+    Unauthorised = 401
+    Unautheticated = 403
+    Bad_request = 400
+    Okay = 200

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -3,6 +3,7 @@ from tornado.testing import gen_test
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
 from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class CopyDirHandlerTest(BaseHandlerTest):
@@ -46,7 +47,8 @@ class CopyDirHandlerTest(BaseHandlerTest):
             "new files uploaded": 1,
             "files updated": 0,
             "files skipped": 0,
-            "data transferred (bytes)": 100
+            "data transferred (bytes)": 100,
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_dir.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -66,7 +68,8 @@ class CopyDirHandlerTest(BaseHandlerTest):
             new_files_uploaded=1,
             files_updated=0,
             files_skipped=0,
-            data_transferred=100
+            data_transferred=100,
+            status=StatusCodes.Okay
         )
         self.mock_data_replication_service.copy_dir.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -85,7 +88,8 @@ class CopyDirHandlerTest(BaseHandlerTest):
             "new files uploaded": 0,
             "files updated": 0,
             "files skipped": 5,
-            "data transferred (bytes)": 0
+            "data transferred (bytes)": 0,
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_dir.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -105,27 +109,14 @@ class CopyDirHandlerTest(BaseHandlerTest):
             new_files_uploaded=0,
             files_updated=0,
             files_skipped=5,
-            data_transferred=0
+            data_transferred=0,
+            status=StatusCodes.Okay
         )
         self.mock_data_replication_service.copy_dir.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
         # Act
         response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
         # Assert
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == transfer_summary
-
-    @gen_test
-    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
-        # Arrange
-        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
-        self.mock_data_replication_service.copy_dir.return_value = transfer_summary
-        self._set_authentication_authorisation_ok()
-        # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
-        # Assert
-        self.mock_data_replication_service.copy_dir.assert_called_once_with("test-bucket", "test_dir/test_sub_dir")
         assert response_code == 200
         assert response_body['status'] == 'success'
         assert response_body['data'] == transfer_summary

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_dir_handler_test.py
@@ -2,8 +2,8 @@ from tornado.testing import gen_test
 
 from DittoWebApi.src.handlers.copy_dir import CopyDirHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class CopyDirHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -2,8 +2,8 @@ from tornado.testing import gen_test
 
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class CopyNewHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_new_handler_test.py
@@ -3,6 +3,7 @@ from tornado.testing import gen_test
 from DittoWebApi.src.handlers.copy_new import CopyNewHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
 from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class CopyNewHandlerTest(BaseHandlerTest):
@@ -46,7 +47,8 @@ class CopyNewHandlerTest(BaseHandlerTest):
             'new files transferred': 1,
             'files updated': 0,
             'files skipped': 3,
-            'data transferred (bytes)': 100
+            'data transferred (bytes)': 100,
+            'status': StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_new.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -66,7 +68,8 @@ class CopyNewHandlerTest(BaseHandlerTest):
             new_files_uploaded=1,
             files_updated=0,
             files_skipped=3,
-            data_transferred=100
+            data_transferred=100,
+            status=StatusCodes.Okay
         )
         self.mock_data_replication_service.copy_new.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -82,10 +85,7 @@ class CopyNewHandlerTest(BaseHandlerTest):
         # Arrange
         transfer_summary = {
             "message": "objects returned successfully",
-            "objects": [
-                {"object": "file_1.txt", "bucket": "test-bucket"},
-                {"object": "file_2.txt", "bucket": "test-bucket"}
-            ]
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_new.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -105,22 +105,9 @@ class CopyNewHandlerTest(BaseHandlerTest):
             new_files_uploaded=0,
             files_updated=0,
             files_skipped=5,
-            data_transferred=0
+            data_transferred=0,
+            status=StatusCodes.Okay
         )
-        self.mock_data_replication_service.copy_new.return_value = transfer_summary
-        self._set_authentication_authorisation_ok()
-        # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
-        # Assert
-        self.mock_data_replication_service.copy_new.assert_called_once_with("test-bucket", None)
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == transfer_summary
-
-    @gen_test
-    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
-        # Arrange
-        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
         self.mock_data_replication_service.copy_new.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
         # Act

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
@@ -3,8 +3,8 @@ from tornado.testing import gen_test
 from tornado.httpclient import HTTPClientError
 from DittoWebApi.src.handlers.copy_update import CopyUpdateHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class CopyUpdateHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
@@ -1,8 +1,10 @@
+import pytest
 from tornado.testing import gen_test
-
+from tornado.httpclient import HTTPClientError
 from DittoWebApi.src.handlers.copy_update import CopyUpdateHandler
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
 from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class CopyUpdateHandlerTest(BaseHandlerTest):
@@ -46,7 +48,8 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
             'new files uploaded': 2,
             'files updated': 1,
             'files skipped': 3,
-            'data transferred (bytes)': 100
+            'data transferred (bytes)': 100,
+            'status': StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -66,7 +69,8 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
             new_files_uploaded=2,
             files_updated=1,
             files_skipped=3,
-            data_transferred=100
+            data_transferred=100,
+            status=StatusCodes.Okay
         )
         self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -85,7 +89,8 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
             'new files transferred': 0,
             'files updated': 0,
             'files skipped': 5,
-            'data transferred (bytes)': 0
+            'data transferred (bytes)': 0,
+            'status': StatusCodes.Okay
         }
         self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -105,7 +110,8 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
             new_files_uploaded=0,
             files_updated=0,
             files_skipped=5,
-            data_transferred=0
+            data_transferred=0,
+            status=StatusCodes.Okay
         )
         self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
@@ -116,31 +122,18 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
         assert response_body['status'] == 'success'
         assert response_body['data'] == transfer_summary
 
-    @gen_test
-    def test_post_returns_warning_when_nonexistent_bucket_name_provided(self):
-        # Arrange
-        transfer_summary = {"message": "test-bucket does not exist in S3", "objects": []}
-        self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
-        self._set_authentication_authorisation_ok()
-        # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
-        # Assert
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == transfer_summary
 
     @gen_test
-    def test_post_returns_warning_when_directory_empty_or_nonexistent(self):
+    def test_post_returns_400_when_directory_empty_or_nonexistent(self):
         # Arrange
         transfer_summary = {
             "message": "No files found in directory or directory does not exist (some_directory)",
-            "objects": []
+            "status": StatusCodes.Bad_request
         }
         self.mock_data_replication_service.copy_new_and_update.return_value = transfer_summary
         self._set_authentication_authorisation_ok()
         # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_authorised_POST_request(self.standard_body)
         # Assert
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == transfer_summary
+        assert error.value.response.code == 400

--- a/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/copy_update_handler_test.py
@@ -122,7 +122,6 @@ class CopyUpdateHandlerTest(BaseHandlerTest):
         assert response_body['status'] == 'success'
         assert response_body['data'] == transfer_summary
 
-
     @gen_test
     def test_post_returns_400_when_directory_empty_or_nonexistent(self):
         # Arrange

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -65,7 +65,9 @@ class CreateBucketHandlerTest(BaseHandlerTest):
     @gen_test
     def test_post_create_bucket_reports_warning_as_json(self):
         # Arrange
-        action_summary = {"message": "Bucket already exists", "bucket": "some-bucket", "status": StatusCodes.Bad_request}
+        action_summary = {"message": "Bucket already exists",
+                          "bucket": "some-bucket",
+                          "status": StatusCodes.Bad_request}
         self.mock_data_replication_service.create_bucket.return_value = action_summary
         self.mock_security_service.check_credentials.return_value = True
         self.mock_security_service.is_in_group.return_value = True
@@ -74,5 +76,3 @@ class CreateBucketHandlerTest(BaseHandlerTest):
             yield self.send_authorised_POST_request(self.standard_body)
         # Assert
         assert error.value.response.code == 400
-
-

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -4,8 +4,8 @@ from tornado.testing import gen_test
 
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.utils.return_helper import return_bucket_message
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class CreateBucketHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/create_bucket_handler_test.py
@@ -1,8 +1,11 @@
+import pytest
+from tornado.httpclient import HTTPClientError
 from tornado.testing import gen_test
 
 from DittoWebApi.src.handlers.create_bucket import CreateBucketHandler
 from DittoWebApi.src.utils.return_helper import return_bucket_message
 from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class CreateBucketHandlerTest(BaseHandlerTest):
@@ -33,7 +36,7 @@ class CreateBucketHandlerTest(BaseHandlerTest):
     @gen_test
     def test_post_create_bucket_returns_summary_of_new_bucket_when_successful(self):
         # Arrange
-        action_summary = {"message": "Bucket created", "bucket": "some-bucket"}
+        action_summary = {"message": "Bucket created", "bucket": "some-bucket", "status": StatusCodes.Okay}
         self.mock_data_replication_service.create_bucket.return_value = action_summary
         self.mock_security_service.check_credentials.return_value = True
         self.mock_security_service.is_in_group.return_value = True
@@ -48,7 +51,7 @@ class CreateBucketHandlerTest(BaseHandlerTest):
     @gen_test
     def test_post_create_bucket_successful_return_helper_coupled_with_method_schema(self):
         # Arrange
-        action_summary = return_bucket_message("Bucket created", "some-bucket")
+        action_summary = return_bucket_message("Bucket created", "some-bucket", StatusCodes.Okay)
         self.mock_data_replication_service.create_bucket.return_value = action_summary
         self.mock_security_service.check_credentials.return_value = True
         self.mock_security_service.is_in_group.return_value = True
@@ -62,28 +65,14 @@ class CreateBucketHandlerTest(BaseHandlerTest):
     @gen_test
     def test_post_create_bucket_reports_warning_as_json(self):
         # Arrange
-        action_summary = {"message": "Bucket already exists", "bucket": "some-bucket"}
+        action_summary = {"message": "Bucket already exists", "bucket": "some-bucket", "status": StatusCodes.Bad_request}
         self.mock_data_replication_service.create_bucket.return_value = action_summary
         self.mock_security_service.check_credentials.return_value = True
         self.mock_security_service.is_in_group.return_value = True
         # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
+        with pytest.raises(HTTPClientError) as error:
+            yield self.send_authorised_POST_request(self.standard_body)
         # Assert
-        self.mock_data_replication_service.create_bucket.assert_called_once_with("test-bucket")
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == action_summary
+        assert error.value.response.code == 400
 
-    @gen_test
-    def test_post_create_bucket_reports_warning_coupled_with_method_schema(self):
-        # Arrange
-        action_summary = return_bucket_message("Bucket already exists", "some-bucket")
-        self.mock_data_replication_service.create_bucket.return_value = action_summary
-        self.mock_security_service.check_credentials.return_value = True
-        self.mock_security_service.is_in_group.return_value = True
-        # Act
-        response_body, response_code = yield self.send_authorised_POST_request(self.standard_body)
-        # Assert
-        assert response_code == 200
-        assert response_body['status'] == 'success'
-        assert response_body['data'] == action_summary
+

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -23,7 +23,7 @@ class DeleteFileHandlerTest(BaseHandlerTest):
         with pytest.raises(tornado.httpclient.HTTPClientError) as error:
             yield self.send_DELETE_request(body)
         # Assert
-        self.mock_security_service.check_credentials.assert_not_called
+        self.mock_security_service.check_credentials.assert_not_called()
         assert error.value.response.code == 401
 
     @gen_test

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -5,8 +5,8 @@ import tornado.web
 
 from DittoWebApi.src.handlers.delete_file import DeleteFileHandler
 from DittoWebApi.src.utils.return_helper import return_delete_file_helper
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class DeleteFileHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/delete_file_handler_test.py
@@ -137,4 +137,4 @@ class DeleteFileHandlerTest(BaseHandlerTest):
         with pytest.raises(HTTPClientError) as error:
             yield self.send_authorised_DELETE_request(body)
         # Assert
-        error.value.response.code == 404
+        assert error.value.response.code == 404

--- a/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
@@ -5,6 +5,7 @@ from tornado.httpclient import HTTPClientError
 
 from DittoWebApi.src.handlers.list_present import ListPresentHandler
 from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class ListPresentHandlerTest(BaseHandlerTest):
@@ -47,7 +48,8 @@ class ListPresentHandlerTest(BaseHandlerTest):
             "message": "objects returned successfully",
             "objects": [
                 {"object": "file_1.txt", "bucket": "test-bucket"}
-            ]
+            ],
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
         self._set_authentication_authorisation_ok()
@@ -67,7 +69,8 @@ class ListPresentHandlerTest(BaseHandlerTest):
             "objects": [
                 {"object": "file_1.txt", "bucket": "test-bucket"},
                 {"object": "file_2.txt", "bucket": "test-bucket"}
-            ]
+            ],
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
         self._set_authentication_authorisation_ok()
@@ -84,7 +87,8 @@ class ListPresentHandlerTest(BaseHandlerTest):
         # Arrange
         object_dicts = {
             "message": "no objects in S3 bucket",
-            "objects": []
+            "objects": [],
+            "status": StatusCodes.Okay
         }
         self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
         self._set_authentication_authorisation_ok()
@@ -95,31 +99,3 @@ class ListPresentHandlerTest(BaseHandlerTest):
         assert response_code == 200
         assert response_body['status'] == 'success'
         assert response_body['data'] == object_dicts
-
-    @gen_test
-    def test_post_returns_404_warning_when_nonexistent_bucket_name_provided(self):
-        # Arrange
-        object_dicts = {"message": "test-bucket does not exist in S3", "objects": []}
-        self.mock_data_replication_service.retrieve_object_dicts.return_value = object_dicts
-        self.mock_security_service.check_credentials.return_value = True
-        body = {'bucket': 'test-bucket12343', }
-        # Act
-        with pytest.raises(HTTPClientError) as error:
-            yield self.send_authorised_POST_request(body)
-        assert error.value.response.code == 404
-        #response_body, response_code = yield self.send_authorised_POST_request(body)
-        # Assert
-        #self.assert_post_returns_404_when_trying_to_access_data_not_found()
-        #self.mock_data_replication_service.retrieve_object_dicts.assert_called_once_with("test-bucket", None)
-        #assert response_code == 404
-        #assert response_body['status'] == 'success'
-        #assert response_body['data'] == object_dicts
-    def assert_post_returns_404_when_trying_to_access_data_not_found(self):
-        # Arrange
-        self.mock_security_service.check_credentials.return_value = False
-        # Act
-        body = {'bucket': "test-bucket", }
-        with pytest.raises(HTTPClientError) as error:
-            yield self.send_authorised_POST_request(body)
-        # Assert
-        assert error.value.response.code == 404

--- a/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
+++ b/ditto_web_api/DittoWebApi/tests/handlers/list_present_handler_test.py
@@ -1,11 +1,8 @@
-import pytest
-
 from tornado.testing import gen_test
-from tornado.httpclient import HTTPClientError
 
 from DittoWebApi.src.handlers.list_present import ListPresentHandler
-from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 from DittoWebApi.src.utils.return_status import StatusCodes
+from DittoWebApi.tests.handlers.base_handler_test import BaseHandlerTest
 
 
 class ListPresentHandlerTest(BaseHandlerTest):

--- a/ditto_web_api/DittoWebApi/tests/services/external_data_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/external_data_services_test.py
@@ -12,6 +12,7 @@ from DittoWebApi.src.models.file_information import FileInformation
 from DittoWebApi.src.models.file_storage_summary import FilesStorageSummary
 from DittoWebApi.src.utils.configurations import Configuration
 from DittoWebApi.src.utils.file_system.files_system_helpers import FileSystemHelper
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class TestExternalDataServices:
@@ -383,7 +384,8 @@ class TestExternalDataServices:
                           "new_files_uploaded": 1,
                           "files_updated": 1,
                           "files_skipped": 1,
-                          "data_transferred": 26}
+                          "data_transferred": 26,
+                          "status": StatusCodes.Okay}
         self.mock_logger.debug.assert_any_call("New files transferred: ['test_file_1.txt']")
         self.mock_logger.debug.assert_any_call("Files updated: ['test_file_2.txt']")
         self.mock_logger.debug.assert_any_call("Files not uploaded or updated: ['test_file_3.txt']")

--- a/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/return_helper_test.py
@@ -1,5 +1,6 @@
 import unittest
 from DittoWebApi.src.utils.return_helper import return_transfer_summary
+from DittoWebApi.src.utils.return_status import StatusCodes
 
 
 class TestReturnHelper(unittest.TestCase):
@@ -9,23 +10,27 @@ class TestReturnHelper(unittest.TestCase):
                                             files_skipped=2,
                                             files_updated=4,
                                             data_transferred=102,
-                                            message=message)
+                                            message=message,
+                                            status=StatusCodes.Okay)
         self.assertEqual(test_dict, {"message": message,
                                      "new files uploaded": 5,
                                      "files updated": 4,
                                      "files skipped": 2,
-                                     "data transferred (bytes)": 102})
+                                     "data transferred (bytes)": 102,
+                                     "status": StatusCodes.Okay})
 
     def test_correct_return_when__no_message_is_added_for_return_dict(self):
         test_dict = return_transfer_summary(new_files_uploaded=6,
                                             files_skipped=3,
                                             files_updated=1,
-                                            data_transferred=2532, )
+                                            data_transferred=2532,
+                                            status=StatusCodes.Okay)
         self.assertEqual(test_dict, {"message": "",
                                      "new files uploaded": 6,
                                      "files updated": 1,
                                      "files skipped": 3,
-                                     "data transferred (bytes)": 2532})
+                                     "data transferred (bytes)": 2532,
+                                     "status": StatusCodes.Okay})
 
     def test_default_dict_returned_when_return_dict_called_with_no_args(self):
         test_dict = return_transfer_summary()
@@ -33,4 +38,5 @@ class TestReturnHelper(unittest.TestCase):
                                      "new files uploaded": 0,
                                      "files updated": 0,
                                      "files skipped": 0,
-                                     "data transferred (bytes)": 0})
+                                     "data transferred (bytes)": 0,
+                                     "status": StatusCodes.Okay})

--- a/systemTests/testScenarios/test_copydir.py
+++ b/systemTests/testScenarios/test_copydir.py
@@ -22,7 +22,6 @@ class TestCopyDir(BaseSystemTest):
         # try copy dir before directory formed
         self.when.authorised_copy_dir_called_for_whole_directory()
 
-        #self.then.response_message_reports_directory_does_not_exist()
         self.then.response_status_is_404()
 
     def test_copy_dir_copies_whole_directory_into_s3_bucket(self):

--- a/systemTests/testScenarios/test_copydir.py
+++ b/systemTests/testScenarios/test_copydir.py
@@ -22,7 +22,8 @@ class TestCopyDir(BaseSystemTest):
         # try copy dir before directory formed
         self.when.authorised_copy_dir_called_for_whole_directory()
 
-        self.then.response_message_reports_directory_does_not_exist()
+        #self.then.response_message_reports_directory_does_not_exist()
+        self.then.response_status_is_404()
 
     def test_copy_dir_copies_whole_directory_into_s3_bucket(self):
         # Create a basic file

--- a/systemTests/testScenarios/test_copying_and_updating_files.py
+++ b/systemTests/testScenarios/test_copying_and_updating_files.py
@@ -21,7 +21,7 @@ class TestCopyUpdate(BaseSystemTest):
         self.when.authorised_copy_update_called_for_whole_directory()
 
         self.then.response_shows_request_was_completed_successfully()
-        self.then.response_message_reports_directory_does_not_exist()
+        self.then.response_data_reports_directory_does_not_exist()
 
     def test_copy_update_copies_across_whole_dir_that_is_new(self):
         self.given.s3_interface_is_running()

--- a/systemTests/testScenarios/test_copying_and_updating_files.py
+++ b/systemTests/testScenarios/test_copying_and_updating_files.py
@@ -10,7 +10,7 @@ class TestCopyUpdate(BaseSystemTest):
         self.when.authorised_copy_update_called_for_whole_directory()
 
         self.then.standard_s3_bucket_does_not_exist()
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_shows_warning_as_bucket_does_not_exist()
 
     def test_copy_update_fails_when_no_file_in_directory(self):
@@ -20,7 +20,7 @@ class TestCopyUpdate(BaseSystemTest):
 
         self.when.authorised_copy_update_called_for_whole_directory()
 
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_data_reports_directory_does_not_exist()
 
     def test_copy_update_copies_across_whole_dir_that_is_new(self):

--- a/systemTests/testScenarios/test_copying_and_updating_files.py
+++ b/systemTests/testScenarios/test_copying_and_updating_files.py
@@ -44,6 +44,7 @@ class TestCopyUpdate(BaseSystemTest):
 
         self.when.authorised_copy_update_called_for_whole_directory()
 
+        self.then.response_shows_request_was_completed_successfully()
         self.then.response_shows_one_file_skipped()
         self.then.response_indicates_no_files_updated()
         self.then.response_indicates_no_new_file_uploaded()

--- a/systemTests/testScenarios/test_copying_new_files.py
+++ b/systemTests/testScenarios/test_copying_new_files.py
@@ -20,7 +20,7 @@ class TestCopyNew(BaseSystemTest):
         self.when.authorised_copy_new_called_for_whole_directory()
 
         self.then.response_shows_request_was_completed_successfully()
-        self.then.response_message_reports_directory_does_not_exist()
+        self.then.response_data_reports_directory_does_not_exist()
 
     def test_copy_new_copies_whole_dir_not_on_s3_to_s3(self):
         self.given.s3_interface_is_running()

--- a/systemTests/testScenarios/test_copying_new_files.py
+++ b/systemTests/testScenarios/test_copying_new_files.py
@@ -9,7 +9,7 @@ class TestCopyNew(BaseSystemTest):
         self.when.authorised_copy_new_called_for_whole_directory()
 
         self.then.standard_s3_bucket_does_not_exist()
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_shows_warning_as_bucket_does_not_exist()
 
     def test_copy_new_fails_when_no_dir_to_copy(self):
@@ -19,7 +19,7 @@ class TestCopyNew(BaseSystemTest):
 
         self.when.authorised_copy_new_called_for_whole_directory()
 
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_data_reports_directory_does_not_exist()
 
     def test_copy_new_copies_whole_dir_not_on_s3_to_s3(self):

--- a/systemTests/testScenarios/test_deleting_a_file.py
+++ b/systemTests/testScenarios/test_deleting_a_file.py
@@ -32,7 +32,7 @@ class TestDeleteFile(BaseSystemTest):
         self.when.authorised_delete_file_is_called_for_simple_file_in_s3()
 
         self.then.response_shows_request_was_completed_successfully()
-        self.then.response_message_reports_simple_file_does_not_exist()
+        self.then.response_data_reports_simple_file_does_not_exist()
 
     def test_delete_file_fails_when_user_not_authorised_for_bucket(self):
         # Start the api

--- a/systemTests/testScenarios/test_deleting_a_file.py
+++ b/systemTests/testScenarios/test_deleting_a_file.py
@@ -9,7 +9,7 @@ class TestDeleteFile(BaseSystemTest):
         self.when.authorised_delete_file_is_called_for_simple_file_in_s3()
 
         self.then.standard_s3_bucket_does_not_exist()
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_shows_warning_as_bucket_does_not_exist()
 
     def test_delete_file_removes_simple_file_from_s3(self):
@@ -31,7 +31,7 @@ class TestDeleteFile(BaseSystemTest):
 
         self.when.authorised_delete_file_is_called_for_simple_file_in_s3()
 
-        self.then.response_shows_request_was_completed_successfully()
+        self.then.response_status_is_404()
         self.then.response_data_reports_simple_file_does_not_exist()
 
     def test_delete_file_fails_when_user_not_authorised_for_bucket(self):

--- a/systemTests/testScenarios/test_list_present.py
+++ b/systemTests/testScenarios/test_list_present.py
@@ -10,6 +10,7 @@ class TestListPresent(BaseSystemTest):
 
         self.then.standard_s3_bucket_does_not_exist()
         self.then.response_shows_warning_as_bucket_does_not_exist()
+        self.then.response_status_is_404()
 
     def test_list_present_shows_content_of_directory(self):
         self.given.s3_interface_is_running()

--- a/systemTests/testScenarios/then/then_steps.py
+++ b/systemTests/testScenarios/then/then_steps.py
@@ -101,9 +101,9 @@ class ThenSteps:
 
     def response_shows_error_that_bad_bucket_name_given(self):
         assert "Bucket name breaks S3 naming convention" in \
-               self._context.response_data()["message"] or \
+               self._context.response_data() or \
                "Bucket breaks local naming standard" in\
-               self._context.response_data()["message"]
+               self._context.response_data()
 
     def response_confirms_simple_file_deleted(self):
         assert self._context.response_data()["message"] == 'File testA.txt successfully deleted ' \
@@ -122,11 +122,11 @@ class ThenSteps:
         assert self._context.response_data()["files updated"] == 1
 
     def response_data_reports_simple_file_does_not_exist(self):
-        assert self._context.response_data()["data"] == "File testA.txt does not exist" \
+        assert self._context.response_data() == "File testA.txt does not exist" \
                                                                    " in bucket systemtest-textbucket"
 
     def response_data_reports_directory_does_not_exist(self):
-        assert self._context.response_data()["data"] == "No files found in directory" \
+        assert self._context.response_data() == "No files found in directory" \
                                                                    " or directory does not exist (root)"
 
     def response_fails_with_reason_authentication_required(self):

--- a/systemTests/testScenarios/then/then_steps.py
+++ b/systemTests/testScenarios/then/then_steps.py
@@ -96,7 +96,7 @@ class ThenSteps:
         assert self._context.response_data()["new files uploaded"] == 1
 
     def response_shows_warning_as_bucket_does_not_exist(self):
-        assert self._context.response_data()["message"] == "Warning, bucket does not exist " \
+        assert self._context.response_data() == "Warning, bucket does not exist " \
                                                                    "(systemtest-textbucket)"
 
     def response_shows_error_that_bad_bucket_name_given(self):
@@ -121,21 +121,28 @@ class ThenSteps:
     def response_message_body_indicates_one_file_updated(self):
         assert self._context.response_data()["files updated"] == 1
 
-    def response_message_reports_simple_file_does_not_exist(self):
-        assert self._context.response_data()["message"] == "File testA.txt does not exist" \
+    def response_data_reports_simple_file_does_not_exist(self):
+        assert self._context.response_data()["data"] == "File testA.txt does not exist" \
                                                                    " in bucket systemtest-textbucket"
 
-    def response_message_reports_directory_does_not_exist(self):
-        assert self._context.response_data()["message"] == "No files found in directory" \
+    def response_data_reports_directory_does_not_exist(self):
+        assert self._context.response_data()["data"] == "No files found in directory" \
                                                                    " or directory does not exist (root)"
 
     def response_fails_with_reason_authentication_required(self):
-        assert json.loads(self._context.http_client_response.text)["reason"] == "Authentication required"
+        assert json.loads(self._context.http_client_response.text)["data"] == "Authentication required"
         assert self._context.http_client_response.status_code == 401
 
     def response_shows_failed_as_unauthorised(self):
-        assert self._context.http_client_response.json()['reason'] == 'Not authorised for this bucket'
+        assert self._context.http_client_response.json()['data'] == 'Not authorised for this bucket'
         assert self._context.http_client_response.status_code == 403
+
+    def response_status_is_400(self):
+        assert self._context.http_client_response.status_code == 400
+
+    def response_status_is_404(self):
+        assert self._context.http_client_response.status_code == 404
+
     def archive_file_exists_in_root_dir(self):
         file_path = os.path.join(self._context.local_data_folder_path, ".ditto_archived")
         assert os.path.exists(file_path)


### PR DESCRIPTION
Implemented 400 status code for bad requests and 404 status codes for requesting missing information. Failed requests now raise an API exception which doesn't conflict with schema validation and returns a response in the form of `status: fail, data: reason why failed`. Unit tests and system tests have been updated to include checks of the status codes and reasons for failure.

## To test:
* Run system tests
* Run unit tests
* Load up API and try making requests with buckets that don't exist, deleting files that don't exist, copy directories that don't exist etc

## Stories covered:
#71 