### PR TITLE
Remove is dir from list present

### DIFF
--- a/ditto_web_api/DittoWebApi/src/models/s3_object_information.py
+++ b/ditto_web_api/DittoWebApi/src/models/s3_object_information.py
@@ -3,7 +3,6 @@ class S3ObjectInformation:
     def __init__(self):
         self._object_name = None
         self._bucket_name = None
-        self._is_dir = None
         self._size = None
         self._etag = None
         self._last_modified = None
@@ -15,10 +14,6 @@ class S3ObjectInformation:
     @property
     def bucket_name(self):
         return self._bucket_name
-
-    @property
-    def is_dir(self):
-        return self._is_dir
 
     @property
     def size(self):
@@ -35,17 +30,15 @@ class S3ObjectInformation:
     def to_dict(self):
         return {"object_name": self.object_name,
                 "bucket_name": self.bucket_name,
-                "is_dir": self.is_dir,
                 "size": self.size,
                 "etag": self.etag,
                 "last modified": self.last_modified}
 
     @staticmethod
-    def create(object_name, bucket_name, is_dir, size, etag, last_modified):
+    def create(object_name, bucket_name, size, etag, last_modified):
         output = S3ObjectInformation()
         output._object_name = object_name
         output._bucket_name = bucket_name
-        output._is_dir = is_dir
         output._size = size
         output._etag = etag
         output._last_modified = last_modified.timestamp()

--- a/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
+++ b/ditto_web_api/DittoWebApi/src/services/external/external_data_service.py
@@ -122,7 +122,6 @@ class ExternalDataService:
         return S3ObjectInformation.create(
             boto_object.name,
             boto_object.bucket.name,
-            False,
             boto_object.size,
             boto_object.etag,
             dateutil.parser.parse(boto_object.last_modified)

--- a/ditto_web_api/DittoWebApi/tests/models/s3_object_information_test.py
+++ b/ditto_web_api/DittoWebApi/tests/models/s3_object_information_test.py
@@ -10,7 +10,6 @@ class TestS3ObjectInformation(unittest.TestCase):
         test_object = S3ObjectInformation.create(
             "test_1.txt",
             "bucket_1_test",
-            False,
             100,
             "test_etag",
             datetime.datetime(2018, 11, 15)
@@ -20,7 +19,6 @@ class TestS3ObjectInformation(unittest.TestCase):
         # Assert
         assert output == {'object_name': 'test_1.txt',
                           'bucket_name': 'bucket_1_test',
-                          'is_dir': False,
                           'size': 100,
                           'etag': 'test_etag',
                           'last modified': 1542240000.0}

--- a/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
+++ b/ditto_web_api/DittoWebApi/tests/services/data_replication_services_test.py
@@ -45,21 +45,18 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_object_1 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_1.to_dict.return_value = {"object_name": "test",
                                                    "bucket_name": "test_bucket",
-                                                   "is_dir": False,
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 2132142421.123123}
         self.mock_object_2 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_2.to_dict.return_value = {"object_name": "test_2",
                                                    "bucket_name": "test_bucket",
-                                                   "is_dir": False,
                                                    "size": 100,
                                                    "etag": "test_etag_2",
                                                    "last_modified": 1124557444.128364}
         self.mock_object_3 = mock.create_autospec(S3ObjectInformation)
         self.mock_object_3.to_dict.return_value = {"object_name": "test_dir/test",
                                                    "bucket_name": "test_bucket",
-                                                   "is_dir": False,
                                                    "size": 100,
                                                    "etag": "test_etag",
                                                    "last_modified": 4132242586.159111}
@@ -104,13 +101,12 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_external_data_service.get_objects.assert_called_once_with("test-bucket", None)
         assert output["objects"][0] == {"object_name": "test",
                                         "bucket_name": "test_bucket",
-                                        "is_dir": False,
                                         "size": 100,
                                         "etag": "test_etag",
                                         "last_modified": 2132142421.123123}
         assert output["objects"][1] == {"object_name": "test_2",
                                         "bucket_name": "test_bucket",
-                                        "is_dir": False, "size": 100,
+                                        "size": 100,
                                         "etag": "test_etag_2",
                                         "last_modified": 1124557444.128364}
         assert len(output["objects"]) == 2
@@ -132,7 +128,6 @@ class DataReplicationServiceTest(unittest.TestCase):
         self.mock_external_data_service.get_objects.assert_called_once_with("test-bucket", "test_dir")
         assert output["objects"][0] == {"object_name": "test_dir/test",
                                         "bucket_name": "test_bucket",
-                                        "is_dir": False,
                                         "size": 100,
                                         "etag": "test_etag",
                                         "last_modified": 4132242586.159111}


### PR DESCRIPTION
Remove is_dir from list present results as was automatically set to false. Old code from minio sdk dependency but now redundant.

## To test:
* Check system and unit tests still run

#3 