### PR TITLE
add .- and -. to invalid items in bucket name

### DIFF
--- a/ditto_web_api/DittoWebApi/src/utils/bucket_helper.py
+++ b/ditto_web_api/DittoWebApi/src/utils/bucket_helper.py
@@ -4,7 +4,8 @@ import re
 def is_valid_bucket(bucket_name):
     if len(bucket_name) < 3 or len(bucket_name) > 63:
         return False
-    if '..' in bucket_name:
+    invalids = ('..', '.-', '-.')
+    if any(invalid_string in bucket_name for invalid_string in invalids):
         return False
     match = re.compile('^[a-z0-9][a-z0-9\\.\\-]+[a-z0-9]$').match(bucket_name)
     if match is None or match.end() != len(bucket_name):

--- a/ditto_web_api/DittoWebApi/tests/services/bucket_validator_tests.py
+++ b/ditto_web_api/DittoWebApi/tests/services/bucket_validator_tests.py
@@ -23,7 +23,9 @@ class TestBucketValidator:
                                              "test!!",
                                              "",
                                              "test-",
-                                             "tests-..bucketname"])
+                                             "tests-..bucketname",
+                                             "test-bucket-.name",
+                                             "test-bucket.-name"])
     def test_check_bucket_returns_warning_when_bucket_name_invalid(self, bucket_name):
         # Act
         bucket_warning = self.test_validator.check_bucket(bucket_name)


### PR DESCRIPTION
Ensure that bucket names containing `.-` or `-.` are classified as invalid and correct error returned. 

## To test:

* Run unit tests

#34 