### PR TITLE
Identical dir paths without final backslash are accepted as equal

### DIFF
--- a/ditto_web_api/DittoWebApi/src/utils/file_system/path_helpers.py
+++ b/ditto_web_api/DittoWebApi/src/utils/file_system/path_helpers.py
@@ -18,4 +18,5 @@ def dir_path_as_prefix(dir_path):
 def is_sub_dir_of_root(directory_path=None, root_path=None):
     # Note should always use canonical paths to ensure correct results
     root_path_as_prefix = dir_path_as_prefix(root_path)
-    return directory_path.startswith(root_path_as_prefix)
+    directory_path_as_prefix = dir_path_as_prefix(directory_path)
+    return directory_path_as_prefix.startswith(root_path_as_prefix)

--- a/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
+++ b/ditto_web_api/DittoWebApi/tests/utils/path_helpers_test.py
@@ -70,19 +70,19 @@ class TestPathHelpers:
         prefix = dir_path_as_prefix(dir_path)
         assert prefix == "testdir/testsubdir/"
 
-    @pytest.mark.parametrize('path', ['path/to/root/file',
-                                      'path/to/root/',
-                                      'path/to/root/dir/sub_dir/file'])
+    @pytest.mark.parametrize('path', ['/path/to/root/file',
+                                      '/path/to/root/',
+                                      '/path/to/root',
+                                      '/path/to/root/dir/sub_dir/file'])
     def test_check_if_sub_dir_of_root_returns_true_when_path_is_in_root(self, path):
-        root = "path/to/root/"
+        root = "/path/to/root"
         assert is_sub_dir_of_root(directory_path=path, root_path=root) is True
 
-    @pytest.mark.parametrize('path', ['path/root/file',
-                                      'path/to/file',
-                                      'to/root/file',
-                                      'path/to/newroot/',
-                                      'path/to/root',
-                                      'path/to/root2/'])
+    @pytest.mark.parametrize('path', ['/path/root/file',
+                                      '/path/to/file',
+                                      '/to/root/file',
+                                      '/path/to/newroot/',
+                                      '/path/to/root2/'])
     def test_check_if_sub_dir_of_root_returns_false_when_path_is_not_in_root(self, path):
-        root = "path/to/root/"
+        root = "/path/to/root"
         assert is_sub_dir_of_root(directory_path=path, root_path=root) is False


### PR DESCRIPTION
While setting up performance tests, I had trouble deleting a file in the bucket root: got a 403 error with the message "Can not access data outside root directory!".

Tracked down the problem to the `is_sub_dir_of_root` method, where both paths were given without a final slash. Adding this for the `directory_path` solved the problem.